### PR TITLE
Cameron chc 168 ui for transcribing

### DIFF
--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -134,8 +134,8 @@ a.gray-text:hover {
   padding-right: 0;
 }
 
-input {
-  color: rgba(51,51,51,.7); /* #333333 */
+input, select, textarea {
+  color: rgba(51,51,51,1); /* #333333 */
 }
 
 .py-default {
@@ -374,6 +374,10 @@ input {
   padding-left: 0;
 }
 
+input {
+  color: rgba(51,51,51,1);
+}
+
 .btn-primary {
   background-color: rgba(0,97,142,1);
   border-color: rgba(0,97,142,1);
@@ -412,11 +416,12 @@ input {
   left: 0;
   right: 0;
   bottom: 0;
-  margin-top: 60%;
   padding-right: .5rem;
   padding-left: .5rem;
-  /* padding: 15% .5rem .5rem; */
-  /* margin: 66.667% 0 0; */
+}
+
+.card-img-overlay-featured {
+  margin-top: 60%;
 }
 
 .card-title {
@@ -428,7 +433,6 @@ input {
 }
 
 .latestblog-imgmask {
-  /* width: 12.5rem; */
   width: 100%;
   height: 12.5rem;
   border-radius: .25rem;
@@ -447,25 +451,8 @@ input {
   box-shadow: 0 0 .25rem rgba(51,51,51,.8);
 }
 
-.loader {
-  border: 16px solid rgba(238,238,238,1);
-  border-radius: 50%;
-  border-top: 16px solid #3498db;
-  width: 120px;
-  height: 120px;
-  -webkit-animation: spin 2s linear infinite; /* Safari */
-  animation: spin 2s linear infinite;
-}
-
-/* Safari */
-@-webkit-keyframes spin {
-  0% { -webkit-transform: rotate(0deg); }
-  100% { -webkit-transform: rotate(360deg); }
-}
-
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+.collection-image-link {
+  z-index: 2;
 }
 
 .loading {
@@ -476,14 +463,14 @@ input {
     background-color: rgba(51,51,51,.3);
     top: 0;
     left: 0;
-    padding-top: 18%;
+    padding-top: 20%;
 }
 
 .loading-pulse {
   position: relative;
   z-index: 2000;
   width: .375rem;
-  height: 1.5rem;
+  height: 3rem;
   background: rgba(0,97,142,.3);
   -webkit-animation: pulse 750ms infinite;
           animation: pulse 750ms infinite;
@@ -495,7 +482,7 @@ input {
   content: '';
   position: absolute;
   display: block;
-  height: 1rem;
+  height: 2rem;
   width: .375rem;
   background: rgba(0,97,142,.4);
   top: 50%;
@@ -568,7 +555,7 @@ input {
 }
 
 .tab-pane textarea {
-  color: rgba(250,250,250,1);
+  background-color: rgba(250,250,250,1);
   height: 100%;
   border: 1px solid rgba(245,245,245,1);
 }

--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -134,8 +134,12 @@ a.gray-text:hover {
   padding-right: 0;
 }
 
-input, select, textarea {
-  color: rgba(51,51,51,1); /* #333333 */
+main {
+  min-height: calc(100vh - 4.5rem);
+}
+
+input {
+  color: rgba(51,51,51,.7); /* #333333 */
 }
 
 .py-default {
@@ -154,12 +158,12 @@ input, select, textarea {
 }
 
 .navbar-offwhite .navbar-nav .active>.nav-link, .navbar-offwhite .navbar-nav .nav-link.active, .navbar-offwhite .navbar-nav .nav-link.show, .navbar-offwhite .navbar-nav .show>.nav-link {
-  color: rgba(51,51,51,.7);  /* #333333 */
+  color: rgba(51,51,51,.7); /* #333333 */
 }
 
 .navbar-offwhite .navbar-nav .nav-link {
   font-family: "Open Sans", sans-serif;
-  color: rgba(51,51,51,1);
+  color: rgba(51,51,51,1); /* #333333 */
 }
 
 .nav-dropdown .dropdown-menu {
@@ -168,7 +172,7 @@ input, select, textarea {
 }
 
 .img-header {
-  background-color: rgba(51,51,51,.35);
+  background-color: rgba(51,51,51,.35); /* #333333 */
   background-image: url("../img/volunteer-header-one-crop.jpg");
   background-blend-mode:overlay;
   background-size: cover, 100% auto;
@@ -179,8 +183,8 @@ input, select, textarea {
 }
 
 .padding-header {
-  padding-top: calc( ( 450px - 147px ) / 2 ); /* vertically center text and button */
-  padding-bottom: calc( ( 450px - 147px ) / 2 );
+  padding-top: calc( ( 28.125rem - 9.1875rem ) / 2 ); /* vertically center text and button */
+  padding-bottom: calc( ( 28.125rem - 9.1875rem ) / 2 );
 }
 
 .margin-default, .mxy-default {
@@ -374,10 +378,6 @@ input, select, textarea {
   padding-left: 0;
 }
 
-input {
-  color: rgba(51,51,51,1);
-}
-
 .btn-primary {
   background-color: rgba(0,97,142,1);
   border-color: rgba(0,97,142,1);
@@ -412,16 +412,21 @@ input {
   padding: 1rem .5rem;
 }
 
+.card-img-collection {
+  object-position: center top;
+  object-fit: cover;
+  height: 18.75rem;
+}
+
 .card-img-overlay {
   left: 0;
   right: 0;
   bottom: 0;
+  margin-top: 60%;
   padding-right: .5rem;
   padding-left: .5rem;
-}
-
-.card-img-overlay-featured {
-  margin-top: 60%;
+  /* padding: 15% .5rem .5rem; */
+  /* margin: 66.667% 0 0; */
 }
 
 .card-title {
@@ -433,11 +438,12 @@ input {
 }
 
 .latestblog-imgmask {
+  /* width: 12.5rem; */
   width: 100%;
   height: 12.5rem;
   border-radius: .25rem;
   overflow: hidden;
-  box-shadow: 0 0 4px rgba(51,51,51,.7);
+  box-shadow: 0 0 .25rem rgba(51,51,51,.7);
 }
 
 .img-latestblog {
@@ -451,26 +457,22 @@ input {
   box-shadow: 0 0 .25rem rgba(51,51,51,.8);
 }
 
-.collection-image-link {
-  z-index: 2;
-}
-
 .loading {
   position: fixed;
     width:  100%;
     height:  100%;
     z-index: 1000;
-    background-color: rgba(51,51,51,.3);
+    background-color: rgba(51,51,51,.5);
     top: 0;
     left: 0;
-    padding-top: 20%;
+    padding-top: 18%;
 }
 
 .loading-pulse {
   position: relative;
   z-index: 2000;
   width: .375rem;
-  height: 3rem;
+  height: 1.5rem;
   background: rgba(0,97,142,.3);
   -webkit-animation: pulse 750ms infinite;
           animation: pulse 750ms infinite;
@@ -482,7 +484,7 @@ input {
   content: '';
   position: absolute;
   display: block;
-  height: 2rem;
+  height: 1rem;
   width: .375rem;
   background: rgba(0,97,142,.4);
   top: 50%;
@@ -514,12 +516,7 @@ input {
 }
 
 .contribute-box {
-  height: calc( 33.3vh );
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  cursor: move;
-  z-index: 2;
+  height: calc( 100vh - 6.0625rem );
 }
 
 .contribute-box .dropdown-menu {
@@ -535,6 +532,7 @@ input {
   color: rgba(250,250,250,1);
   border-radius: 1rem;
   text-decoration: underline;
+  font-size: .875rem;
 }
 
 .nav-pills .nav-link.active {
@@ -544,13 +542,13 @@ input {
 }
 
 .tab-content, .tab-pane {
-  height: calc( 33.3vh - ( 56px + 54px ) );
+  height: calc( 33.3vh - ( 3.5rem + 3.375rem ) );
   overflow-y: scroll;
 }
 
 /* CONTRIBUTE PAGE INLINED STYLES */
 .asset-image {
-  height: calc( 100vh - 97px );
+  height: calc( 100vh - 6.0625rem );
   border: 1px solid rgba(245,245,245,1);
 }
 
@@ -566,7 +564,7 @@ input {
 
 .tab-pane input {
   color: rgba(51,51,51,1);
-  height: calc( 50vh - ( 56px + 54px ) );
+  height: calc( 50vh - ( 3.5rem + 3.375rem ) );
 }
 
 #tab-discussion {
@@ -583,12 +581,12 @@ background-color: #fff;
 border: 1px solid #ccc;
 box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
 display: inline-block;
-padding: 4px 6px;
+padding: .25rem .375rem;
 color: #555;
 vertical-align: middle;
-border-radius: 4px;
+border-radius: .25rem;
 width: 100%;
-line-height: 22px;
+line-height: 1.375rem;
 cursor: text;
 }
 .bootstrap-tagsinput input {
@@ -596,7 +594,7 @@ border: none;
 box-shadow: none;
 outline: none;
 background-color: transparent;
-padding: 0 6px;
+padding: 0 .375rem;
 margin: 0;
 width: auto;
 max-width: inherit;
@@ -617,11 +615,12 @@ box-shadow: none;
 }
 
 .bootstrap-tagsinput .badge {
-margin-right: 2px;
+margin-right: .125rem;
 color: white;
-background-color:#0275d8;
-padding:5px 8px;border-radius:3px;
-border:1px solid #01649e
+background-color: #0275d8;
+padding: .3125rem .5rem;
+border-radius: 3px;
+border: 1px solid #01649e;
 }
 
 .bootstrap-tagsinput .badge [data-role="remove"] {
@@ -631,10 +630,10 @@ cursor: pointer;
 
 .bootstrap-tagsinput .badge [data-role="remove"]:after {
 content: "×";
-padding: 0px 4px;
-background-color:rgba(0, 0, 0, 0.1);
-border-radius:50%;
-font-size:13px
+padding: 0 .25rem;
+background-color: rgba(0, 0, 0, 0.1);
+border-radius: 50%;
+font-size: .87;
 }
 
 .bootstrap-tagsinput .badge [data-role="remove"]:hover:after {
@@ -642,12 +641,12 @@ background-color:rgba(0, 0, 0, 0.62);
 }
 
 .bootstrap-tagsinput .badge [data-role="remove"]:hover:active {
-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+box-shadow: inset 0 .1875rem .3125rem rgba(0, 0, 0, 0.125);
 }
 
 /* #nav-tags .bootstrap-tagsinput{
 height:100%;
 } */
 #nav-tags .badge{
-margin-top: 5px;
+margin-top: .3125rem;
 }

--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -515,6 +515,13 @@ input {
   }
 }
 
+/* Contribute page CSS */
+
+.asset-image {
+  height: calc( 100vh - 6.0625rem );
+  border: 1px solid rgba(245,245,245,1);
+}
+
 .contribute-box {
   height: calc( 100vh - 6.0625rem );
 }
@@ -542,20 +549,15 @@ input {
 }
 
 .tab-content, .tab-pane {
-  height: calc( 33.3vh - ( 3.5rem + 3.375rem ) );
+  height: calc( 40vh - ( 3.5rem + 3.375rem ) );
   overflow-y: scroll;
-}
-
-/* CONTRIBUTE PAGE INLINED STYLES */
-.asset-image {
-  height: calc( 100vh - 6.0625rem );
-  border: 1px solid rgba(245,245,245,1);
 }
 
 .tab-pane textarea {
   background-color: rgba(250,250,250,1);
   height: 100%;
   border: 1px solid rgba(245,245,245,1);
+  resize: none;
 }
 
 .tab-pane textarea::-webkit-input-placeholder, .tab-pane textarea::-moz-placeholder, .tab-pane textarea:-ms-input-placeholder, .tab-pane textarea:-moz-placeholder {
@@ -564,7 +566,8 @@ input {
 
 .tab-pane input {
   color: rgba(51,51,51,1);
-  height: calc( 50vh - ( 3.5rem + 3.375rem ) );
+  height: calc( 40vh - ( 3.5rem + 3.375rem ) );
+  width: 100%;
 }
 
 #tab-discussion {
@@ -573,6 +576,7 @@ input {
 
 #status-id-label {
   color: rgba(250,250,250,1);
+  margin-bottom: 0;
 }
 
 /*
@@ -581,14 +585,15 @@ input {
 */
 
 .bootstrap-tagsinput {
-background-color: #fff;
-border: 1px solid #ccc;
+background-color: rgba(250,250,250,1);
+border: 0px solid #ccc;
 box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
 display: inline-block;
-padding: .25rem .375rem;
-color: #555;
+padding: .5rem;
+color: rgba(61,61,61,1);
 vertical-align: middle;
 border-radius: .25rem;
+max-height: calc( 40vh - ( 3.5rem + 3.375rem ) );
 width: 100%;
 line-height: 1.375rem;
 cursor: text;
@@ -600,7 +605,7 @@ outline: none;
 background-color: transparent;
 padding: 0 .375rem;
 margin: 0;
-width: auto;
+width: 100%;
 max-width: inherit;
 }
 .bootstrap-tagsinput.form-control input::-moz-placeholder {
@@ -620,11 +625,12 @@ box-shadow: none;
 
 .bootstrap-tagsinput .badge {
 margin-right: .125rem;
-color: white;
-background-color: #0275d8;
+color: rgba(250,250,250,1);
+background-color: rgba(0,97,142,1);
 padding: .3125rem .5rem;
 border-radius: 3px;
-border: 1px solid #01649e;
+border: 0px solid transparent;
+box-shadow: 0 0 .125rem rgba(51,51,51,.7);
 }
 
 .bootstrap-tagsinput .badge [data-role="remove"] {
@@ -635,9 +641,9 @@ cursor: pointer;
 .bootstrap-tagsinput .badge [data-role="remove"]:after {
 content: "×";
 padding: 0 .25rem;
-background-color: rgba(0, 0, 0, 0.1);
+background-color: rgba(0,35,71,1);
 border-radius: 50%;
-font-size: .87;
+font-size: .88;
 }
 
 .bootstrap-tagsinput .badge [data-role="remove"]:hover:after {

--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -135,7 +135,7 @@ a.gray-text:hover {
 }
 
 main {
-  min-height: calc( 100vh - 4.5rem );
+  min-height: calc(100vh - 4.5rem);
 }
 
 input {
@@ -422,7 +422,7 @@ input {
   left: 0;
   right: 0;
   bottom: 0;
-  margin-top: 46%;
+  margin-top: 60%;
   padding-right: .5rem;
   padding-left: .5rem;
   /* padding: 15% .5rem .5rem; */
@@ -528,29 +528,28 @@ input {
   background: rgba(0,97,142,1);
 }
 
-#nav-pill-contribute-box .nav-link {
+.nav-pills .nav-link {
   color: rgba(250,250,250,1);
   border-radius: 1rem;
   text-decoration: underline;
   font-size: .875rem;
 }
 
-#nav-pill-contribute-box .nav-link.active {
+.nav-pills .nav-link.active {
   color: rgba(250,250,250,1);
   background-color: rgba(0,97,142,1);
   text-decoration: none;
 }
 
-.tab-content, .tab-pane, .tab-pane input {
-  color: rgba(51,51,51,1);
-  height: calc( 50vh - ( 3.5rem + 3.375rem ) );
+.tab-content, .tab-pane {
+  height: calc( 33.3vh - ( 3.5rem + 3.375rem ) );
   overflow-y: scroll;
 }
 
-/* CONTRIBUTE PAGE */
+/* CONTRIBUTE PAGE INLINED STYLES */
 .asset-image {
   height: calc( 100vh - 6.0625rem );
-  border: 0px solid #000000;
+  border: 1px solid rgba(245,245,245,1);
 }
 
 .tab-pane textarea {
@@ -563,11 +562,23 @@ input {
   color: rgba(102,102,102,1);
 }
 
+.tab-pane input {
+  color: rgba(51,51,51,1);
+  height: calc( 50vh - ( 3.5rem + 3.375rem ) );
+}
+
 #tab-discussion {
   background-color: rgba(250,250,250,1);
 }
 
-/* bootstrap-tagsinput v0.8.0 */
+#status-id-label {
+  color: rgba(250,250,250,1);
+}
+
+/*
+* bootstrap-tagsinput v0.8.0
+*
+*/
 
 .bootstrap-tagsinput {
 background-color: #fff;
@@ -640,6 +651,15 @@ box-shadow: inset 0 .1875rem .3125rem rgba(0, 0, 0, 0.125);
 /* #nav-tags .bootstrap-tagsinput{
 height:100%;
 } */
-#nav-tags .badge{
+#nav-tags .badge {
 margin-top: .3125rem;
+}
+
+/* Registration styling */
+.form-register input {
+
+}
+
+.form-register label {
+  padding-right: .5rem;
 }

--- a/concordia/static/js/contribute.js
+++ b/concordia/static/js/contribute.js
@@ -1,42 +1,7 @@
-//Make the DIV element draggagle:
-dragElement(document.getElementById(("contribute-box")));
-
-function dragElement(elmnt) {
-  var pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
-  if (document.getElementById(elmnt.id + "-tabs")) {
-    /* if present, the header is where you move the DIV from: */
-    document.getElementById(elmnt.id + "-tabs").onmousedown = dragMouseDown;
+$('#nav-pill-transcription, #nav-pill-tag, #nav-pill-discussion').mouseup(function() {
+  if ( !$('#nav-pill-transcription').hasClass('active') ) {
+    $('#status-id,#status-id-label').addClass('d-none');
   } else {
-    /* otherwise, move the DIV from anywhere inside the DIV: */
-    elmnt.onmousedown = dragMouseDown;
-  }
-
-  function dragMouseDown(e) {
-    e = e || window.event;
-    // get the mouse cursor position at startup:
-    pos3 = e.clientX;
-    pos4 = e.clientY;
-    document.onmouseup = closeDragElement;
-    // call a function whenever the cursor moves:
-    document.onmousemove = elementDrag;
-  }
-
-  function elementDrag(e) {
-    e = e || window.event;
-    // calculate the new cursor position:
-    pos1 = pos3 - e.clientX;
-    pos2 = pos4 - e.clientY;
-    pos3 = e.clientX;
-    pos4 = e.clientY;
-    // set the element's new position:
-    // Need if statemements to keep on screen
-    elmnt.style.top = (elmnt.offsetTop - pos2) + "px";
-    elmnt.style.left = (elmnt.offsetLeft - pos1) + "px";
-  }
-
-  function closeDragElement() {
-    /* stop moving when mouse button is released: */
-    document.onmouseup = null;
-    document.onmousemove = null;
-  }
-}
+    $('#status-id,#status-id-label').removeClass('d-none');
+    }
+});

--- a/concordia/static/js/contribute.js
+++ b/concordia/static/js/contribute.js
@@ -1,7 +1,10 @@
 $('#nav-pill-transcription, #nav-pill-tag, #nav-pill-discussion').click(function( e ) {
   if ( e.target.id == 'nav-pill-transcription' ) {
-    $('#status_id, #status-id-label').removeClass('d-none');
-  } else {
+    $('#status_id,#status-id-label,input.btn-primary').removeClass('d-none');
+  } else if ( e.target.id == 'nav-pill-discussion' ) {
+  	$('#status_id,#status-id-label,input.btn-primary').addClass('d-none');
+  }
+  else {
     $('#status_id,#status-id-label').addClass('d-none');
     }
 });

--- a/concordia/static/js/contribute.js
+++ b/concordia/static/js/contribute.js
@@ -1,7 +1,7 @@
-$('#nav-pill-transcription, #nav-pill-tag, #nav-pill-discussion').mouseup(function() {
-  if ( !$('#nav-pill-transcription').hasClass('active') ) {
-    $('#status-id,#status-id-label').addClass('d-none');
+$('#nav-pill-transcription, #nav-pill-tag, #nav-pill-discussion').click(function( e ) {
+  if ( e.target.id == 'nav-pill-transcription' ) {
+    $('#status_id, #status-id-label').removeClass('d-none');
   } else {
-    $('#status-id,#status-id-label').removeClass('d-none');
+    $('#status_id,#status-id-label').addClass('d-none');
     }
 });

--- a/concordia/templates/home.html
+++ b/concordia/templates/home.html
@@ -31,19 +31,19 @@
             <div class="d-flex flex-wrap col-12 justify-content-around">
               <div class="col-12 col-md-4 col-lg-3 mb-default card home-collections shadow-regular bg-lightest-gray">
                   <img class="card-img" src="{% static "img/AbrahamLincoln.png" %}">
-                  <div class="card-img-overlay bg-card-title">
+                  <div class="card-img-overlay card-img-overlay-featured bg-card-title">
                     <h5 class="card-title align-text-bottom offwhite-text w-100">Abraham Lincoln Papers</h5>
                   </div>
               </div>
               <div class="col-12 col-md-4 col-lg-3 mb-default card home-collections shadow-regular bg-lightest-gray">
                   <img class="card-img" src="{% static "img/BranchRickey.png" %}">
-                  <div class="card-img-overlay bg-card-title">
+                  <div class="card-img-overlay card-img-overlay-featured bg-card-title">
                     <h5 class="card-title align-text-bottom offwhite-text w-100">Branch Rickey Papers</h5>
                   </div>
               </div>
               <div class="col-12 col-md-4 col-lg-3 mb-default card shadow-regular bg-lightest-gray">
                   <img class="card-img" src="{% static "img/ClaraBarton.png" %}">
-                  <div class="card-img-overlay bg-card-title">
+                  <div class="card-img-overlay card-img-overlay-featured bg-card-title">
                     <h5 class="card-title align-text-bottom offwhite-text w-100">Clara Barton Papers</h5>
                   </div>
               </div>

--- a/concordia/templates/transcriptions/asset.html
+++ b/concordia/templates/transcriptions/asset.html
@@ -96,8 +96,8 @@
                     </div>
                   </div>
                 {% if request.user.is_authenticated %}
-                <div class="my-quarter mx-half">
-                  <label id="status-id-label" for="status_id">Transcription Status:</label>
+                <div class="my-quarter d-flex justify-content-around align-items-center">
+                  <label id="status-id-label" for="status_id">Status:</label>
                     <select name="status" id="status_id">
                         <option value="0">0%</option>
                         <option value="25">25%</option>
@@ -105,7 +105,7 @@
                         <option value="75">75%</option>
                         <option value="100">100%</option>
                     </select>
-                    <input type="submit" class="btn btn-primary" value="Save">
+                    <input type="submit" class="btn btn-primary float-right" value="Save">
                   </div>
                   {% endif %}
                 </form>

--- a/concordia/templates/transcriptions/asset.html
+++ b/concordia/templates/transcriptions/asset.html
@@ -97,7 +97,7 @@
                   </div>
                 {% if request.user.is_authenticated %}
                 <div class="my-quarter mx-half">
-                  <label for="status_id">Transcription Status:</label>
+                  <label id="status-id-label" for="status_id">Transcription Status:</label>
                     <select name="status" id="status_id">
                         <option value="0">0%</option>
                         <option value="25">25%</option>
@@ -128,6 +128,7 @@
         }
     });
 </script>
+<script src="{% static "js/contribute.js" %}"></script>
 <script>
 {% if transcription.status %}
   $("#status_id").val({{transcription.status}});

--- a/concordia/templates/transcriptions/asset.html
+++ b/concordia/templates/transcriptions/asset.html
@@ -7,11 +7,11 @@
     <div class="col-12 d-flex align-items-middle py-1 bg-darkest-gray">
       <h6 class="offwhite-text pl-default mb-0"><a class="offwhite-text" href="{% url 'transcriptions:collection' asset.collection.slug %}">{{ asset.collection.title }}</a>  >  {{ asset.title }}</h6>
     </div>
-    <div class="col-12">
+    <div class="col-8 col-md-9">
       <div id="asset-image" class="asset-image bg-offwhite">
         </div>
     </div>
-    <div class="col-6 col-lg-4 bg-darkest-gray shadow-regular rounded contribute-box" id="contribute-box">
+    <div class="col-4 col-md-3 bg-darkest-gray shadow-regular rounded contribute-box" id="contribute-box">
           <nav class="px-half py-1">
             <div class="nav nav-pills" id="nav-pill-contribute-box" role="tablist">
                   <a class="nav-item nav-link active" id="nav-pill-transcription" data-toggle="tab" href="#tab-transcription" role="tab" aria-controls="tab-transcription" aria-selected="true">Transcription</a>
@@ -118,7 +118,6 @@
 {% block body_scripts %}
 <script src="https://www.jqueryscript.net/demo/Bootstrap-4-Tag-Input-Plugin-jQuery/tagsinput.js"></script>
 <script src="{% static "vendor/openseadragon/openseadragon.min.js" %}"></script>
-<script src="{% static "js/contribute.js" %}"></script>
 <script>
     OpenSeadragon({
         id: 'asset-image',

--- a/concordia/templates/transcriptions/asset.html
+++ b/concordia/templates/transcriptions/asset.html
@@ -83,11 +83,13 @@
                                     </div>
                                 </div>
                                 <!-- /comment -->
+                                {% if user.is_authenticated %}
                                 <div class="row pt-2">
                                     <div class="col-12">
                                         <a href="" class="btn btn-sm btn-primary">Comment</a>
                                     </div>
                                 </div>
+                                {% endif %}
 
                             </div>
                         </div>

--- a/concordia/templates/transcriptions/collection.html
+++ b/concordia/templates/transcriptions/collection.html
@@ -13,8 +13,8 @@
                 <div class="d-flex flex-wrap col-12 justify-content-around">
                     {% for a in assets %}
                     <div class="col-12 col-md-4 col-lg-3 mx-quarter mb-default card bg-lightest-gray shadow-regular">
-                        <img class="card-img" src="{{ MEDIA_URL }}{{a.media_url }}" alt="{ a.slug }">
-                        <div class="card-img-overlay">
+                        <a href="{% url 'transcriptions:asset' collection.slug a.slug %}"><img class="card-img" src="{{ MEDIA_URL }}{{a.media_url }}" alt="{ a.slug }"></a>
+                        <div class="card-img-overlay collection-image">
                             <div class="d-flex justify-content-center col-9 col-md-8 mx-auto">
                                 <a href="{% url 'transcriptions:asset' collection.slug a.slug %}" class="btn btn-primary btn-lg w-100">Transcribe</a>
                             </div>
@@ -22,7 +22,7 @@
                                 <a href="{% url 'transcriptions:asset' collection.slug a.slug %}#tab-tag" class="btn btn-primary btn-lg w-100">Tag</a>
                             </div>
                         </div>
-                        <a href="{% url 'transcriptions:asset' collection.slug a.slug %}"><h6 class="text-center blue-text my-half">{{ a.slug }}</h6></a>
+                        <a href="{% url 'transcriptions:asset' collection.slug a.slug %}"><h6 class="text-center blue-text my-half collection-image-link">{{ a.slug }}</h6></a>
                     </div>
                     {% endfor %}
                 </div>

--- a/concordia/templates/transcriptions/collection.html
+++ b/concordia/templates/transcriptions/collection.html
@@ -13,7 +13,7 @@
                 <div class="d-flex flex-wrap col-12 justify-content-around">
                     {% for a in assets %}
                     <div class="col-12 col-md-4 col-lg-3 mx-quarter mb-default card bg-lightest-gray shadow-regular">
-                        <a href="{% url 'transcriptions:asset' collection.slug a.slug %}"><img class="card-img" src="{{ MEDIA_URL }}{{a.media_url }}" alt="{ a.slug }"></a>
+                        <a href="{% url 'transcriptions:asset' collection.slug a.slug %}"><img class="card-img card-img-collection" src="{{ MEDIA_URL }}{{a.media_url }}" alt="{ a.slug }"></a>
                         <div class="card-img-overlay collection-image">
                             <div class="d-flex justify-content-center col-9 col-md-8 mx-auto">
                                 <a href="{% url 'transcriptions:asset' collection.slug a.slug %}" class="btn btn-primary btn-lg w-100">Transcribe</a>

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -541,9 +541,8 @@ input {
   text-decoration: none;
 }
 
-.tab-content, .tab-pane, .tab-pane input {
-  color: rgba(51,51,51,1);
-  height: calc( 50vh - ( 3.5rem + 3.375rem ) );
+.tab-content, .tab-pane {
+  height: calc( 33.3vh - ( 3.5rem + 3.375rem ) );
   overflow-y: scroll;
 }
 
@@ -561,6 +560,11 @@ input {
 
 .tab-pane textarea::-webkit-input-placeholder, .tab-pane textarea::-moz-placeholder, .tab-pane textarea:-ms-input-placeholder, .tab-pane textarea:-moz-placeholder {
   color: rgba(102,102,102,1);
+}
+
+.tab-pane input {
+  color: rgba(51,51,51,1);
+  height: calc( 50vh - ( 3.5rem + 3.375rem ) );
 }
 
 #tab-discussion {

--- a/static/js/contribute.js
+++ b/static/js/contribute.js
@@ -1,0 +1,42 @@
+//Make the DIV element draggagle:
+dragElement(document.getElementById(("contribute-box")));
+
+function dragElement(elmnt) {
+  var pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
+  if (document.getElementById(elmnt.id + "-tabs")) {
+    /* if present, the header is where you move the DIV from: */
+    document.getElementById(elmnt.id + "-tabs").onmousedown = dragMouseDown;
+  } else {
+    /* otherwise, move the DIV from anywhere inside the DIV: */
+    elmnt.onmousedown = dragMouseDown;
+  }
+
+  function dragMouseDown(e) {
+    e = e || window.event;
+    // get the mouse cursor position at startup:
+    pos3 = e.clientX;
+    pos4 = e.clientY;
+    document.onmouseup = closeDragElement;
+    // call a function whenever the cursor moves:
+    document.onmousemove = elementDrag;
+  }
+
+  function elementDrag(e) {
+    e = e || window.event;
+    // calculate the new cursor position:
+    pos1 = pos3 - e.clientX;
+    pos2 = pos4 - e.clientY;
+    pos3 = e.clientX;
+    pos4 = e.clientY;
+    // set the element's new position:
+    // Need if statemements to keep on screen
+    elmnt.style.top = (elmnt.offsetTop - pos2) + "px";
+    elmnt.style.left = (elmnt.offsetLeft - pos1) + "px";
+  }
+
+  function closeDragElement() {
+    /* stop moving when mouse button is released: */
+    document.onmouseup = null;
+    document.onmousemove = null;
+  }
+}


### PR DESCRIPTION
Addressed:
CHC-214 - As a volunteer, I want to click on a thumbnail so that I can view the image
CHC-215 - As a volunteer, I want to be able to type words into a text field that corresponds to with the image
CHC-216 - As a volunteer, I want to be able to save my work so that I can submit a finished transcription

Fixed abnormal sizing of images and whitespace in collection view. Moved contribute box to right-hand side—downsized box navigation text size and fixed the color of text in the transcription and tagging boxes.
Fixed CSS and JS related to contriubute box, as well as some HTML changes to accommodate those changes—hiding status percentage when transcription not chosen on contribute box.
Fixed showing and hiding of transcription status label and percent based on which task is selected in the contribute box as well as the color of the label for the status select.
Made the decision to hide save button when viewing asset-related discussion. Also removed verbiage for status label as it's only shown when transcribing task is selected and changed the layout and spacing of the status and save row of items. Finally, also fixed the alignment of the tags input so the cursor didn't default to the bottom of the input box. Fixed a small matter of the textarea for transcription and tagging thinking it was resizable.