### PR TITLE
Restore --deploy option in Dockerfiles for pipenv install command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN pip3 install pipenv
 COPY vendor /vendor
 WORKDIR /app
 COPY . /app
-RUN pipenv install --system --dev
+RUN pipenv install --system --dev --deploy
 
 EXPOSE 80
 # CMD [ "/bin/bash", "entrypoint.sh" ]

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ Next, set up a Python virtual environment, install pipenv <https://docs.pipenv.o
     $ python3 -m venv .venv
     $ source .venv/bin/activate
     $ pip3 install pipenv
-    $ pipenv install --system --dev --deploy
+    $ pipenv install --dev
 
 
 Finally, configure the Django settings, run migrations, and launch the development server::

--- a/importer/Dockerfile
+++ b/importer/Dockerfile
@@ -23,6 +23,6 @@ RUN pip3 install pipenv
 
 WORKDIR /app
 COPY . /app
-RUN pipenv install --system --dev
+RUN pipenv install --system --dev --deploy
 
 CMD [ "/bin/bash", "importer/entrypoint.sh" ]


### PR DESCRIPTION
Refs #108 in LC github repo - Docker containers should use --deploy option in pipenv command so that dependencies will be locked for those deployments. The README file contains the pipenv command necessary for updating pipfile.lock