### PR TITLE
Tim chc 347 refine bagit export

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ the concordia app and it is not included in the source code respository.
 
 You must create this file in the concordia root directory.
 
-This file contains nine values, which are:
+This file contains several values, which are:
 ::
 
     GRAFANA_ADMIN_PW=<grafana_admin_password_here>

--- a/concordia/management/commands/populate_db.py
+++ b/concordia/management/commands/populate_db.py
@@ -7,7 +7,9 @@ class Command(BaseCommand):
 
     def _add_data(self):
         """
-        Add a collection and 5 assets to db
+        Add a collection with two items to db.  The 1st item has 5 assets and the second item
+        has 3 assets
+
         """
         collection, created = Collection.objects.update_or_create(
             title="Test S3",
@@ -25,6 +27,7 @@ class Command(BaseCommand):
             media_type=MediaType.IMAGE,
             collection=collection,
             metadata={"key": "val2"},
+            sequence=0,
             status=Status.EDIT,
         )
 
@@ -36,6 +39,7 @@ class Command(BaseCommand):
             media_type=MediaType.IMAGE,
             collection=collection,
             metadata={"key": "val2"},
+            sequence=1,
             status=Status.EDIT,
         )
 
@@ -47,6 +51,7 @@ class Command(BaseCommand):
             media_type=MediaType.IMAGE,
             collection=collection,
             metadata={"key": "val2"},
+            sequence=2,
             status=Status.EDIT,
         )
 
@@ -58,6 +63,7 @@ class Command(BaseCommand):
             media_type=MediaType.IMAGE,
             collection=collection,
             metadata={"key": "val2"},
+            sequence=3,
             status=Status.EDIT,
         )
 
@@ -69,6 +75,43 @@ class Command(BaseCommand):
             media_type=MediaType.IMAGE,
             collection=collection,
             metadata={"key": "val2"},
+            sequence=4,
+            status=Status.EDIT,
+        )
+
+        asset6, created = Asset.objects.update_or_create(
+            title="mss859430178",
+            slug="mss8594301780",
+            description="mss859430178",
+            media_url="https://s3.us-east-2.amazonaws.com/chc-collections/test_s3/mss859430178/0.png",
+            media_type=MediaType.IMAGE,
+            collection=collection,
+            metadata={"key": "val2"},
+            sequence=0,
+            status=Status.EDIT,
+        )
+
+        asset7, created = Asset.objects.update_or_create(
+            title="mss859430178",
+            slug="mss8594301781",
+            description="mss859430178",
+            media_url="https://s3.us-east-2.amazonaws.com/chc-collections/test_s3/mss859430178/1.png",
+            media_type=MediaType.IMAGE,
+            collection=collection,
+            metadata={"key": "val2"},
+            sequence=1,
+            status=Status.EDIT,
+        )
+
+        asset8, created = Asset.objects.update_or_create(
+            title="mss859430178",
+            slug="mss8594301782",
+            description="mss859430178",
+            media_url="https://s3.us-east-2.amazonaws.com/chc-collections/test_s3/mss859430178/2.png",
+            media_type=MediaType.IMAGE,
+            collection=collection,
+            metadata={"key": "val2"},
+            sequence=2,
             status=Status.EDIT,
         )
 

--- a/exporter/tests/coverage/_Users_drew_PycharmProjects_concordia-chc-347REVIEWDELETE_concordia_exporter_views_py.html
+++ b/exporter/tests/coverage/_Users_drew_PycharmProjects_concordia-chc-347REVIEWDELETE_concordia_exporter_views_py.html
@@ -1,0 +1,409 @@
+
+
+
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    
+    
+    <meta http-equiv="X-UA-Compatible" content="IE=emulateIE7" />
+    <title>Coverage for /Users/drew/PycharmProjects/concordia-chc-347REVIEWDELETE/concordia/exporter/views.py: 66%</title>
+    <link rel="stylesheet" href="style.css" type="text/css">
+    
+    <script type="text/javascript" src="jquery.min.js"></script>
+    <script type="text/javascript" src="jquery.hotkeys.js"></script>
+    <script type="text/javascript" src="jquery.isonscreen.js"></script>
+    <script type="text/javascript" src="coverage_html.js"></script>
+    <script type="text/javascript">
+        jQuery(document).ready(coverage.pyfile_ready);
+    </script>
+</head>
+<body class="pyfile">
+
+<div id="header">
+    <div class="content">
+        <h1>Coverage for <b>/Users/drew/PycharmProjects/concordia-chc-347REVIEWDELETE/concordia/exporter/views.py</b> :
+            <span class="pc_cov">66%</span>
+        </h1>
+
+        <img id="keyboard_icon" src="keybd_closed.png" alt="Show keyboard shortcuts" />
+
+        <h2 class="stats">
+            85 statements &nbsp;
+            <span class="run hide_run shortkey_r button_toggle_run">56 run</span>
+            <span class="mis shortkey_m button_toggle_mis">29 missing</span>
+            <span class="exc shortkey_x button_toggle_exc">0 excluded</span>
+
+            
+        </h2>
+    </div>
+</div>
+
+<div class="help_panel">
+    <img id="panel_icon" src="keybd_open.png" alt="Hide keyboard shortcuts" />
+    <p class="legend">Hot-keys on this page</p>
+    <div>
+    <p class="keyhelp">
+        <span class="key">r</span>
+        <span class="key">m</span>
+        <span class="key">x</span>
+        <span class="key">p</span> &nbsp; toggle line displays
+    </p>
+    <p class="keyhelp">
+        <span class="key">j</span>
+        <span class="key">k</span> &nbsp; next/prev highlighted chunk
+    </p>
+    <p class="keyhelp">
+        <span class="key">0</span> &nbsp; (zero) top of page
+    </p>
+    <p class="keyhelp">
+        <span class="key">1</span> &nbsp; (one) first highlighted chunk
+    </p>
+    </div>
+</div>
+
+<div id="source">
+    <table>
+        <tr>
+            <td class="linenos">
+<p id="n1" class="stm run hide_run"><a href="#n1">1</a></p>
+<p id="n2" class="stm run hide_run"><a href="#n2">2</a></p>
+<p id="n3" class="stm run hide_run"><a href="#n3">3</a></p>
+<p id="n4" class="stm run hide_run"><a href="#n4">4</a></p>
+<p id="n5" class="pln"><a href="#n5">5</a></p>
+<p id="n6" class="stm run hide_run"><a href="#n6">6</a></p>
+<p id="n7" class="stm run hide_run"><a href="#n7">7</a></p>
+<p id="n8" class="stm run hide_run"><a href="#n8">8</a></p>
+<p id="n9" class="stm run hide_run"><a href="#n9">9</a></p>
+<p id="n10" class="stm run hide_run"><a href="#n10">10</a></p>
+<p id="n11" class="pln"><a href="#n11">11</a></p>
+<p id="n12" class="stm run hide_run"><a href="#n12">12</a></p>
+<p id="n13" class="pln"><a href="#n13">13</a></p>
+<p id="n14" class="pln"><a href="#n14">14</a></p>
+<p id="n15" class="stm run hide_run"><a href="#n15">15</a></p>
+<p id="n16" class="pln"><a href="#n16">16</a></p>
+<p id="n17" class="pln"><a href="#n17">17</a></p>
+<p id="n18" class="pln"><a href="#n18">18</a></p>
+<p id="n19" class="pln"><a href="#n19">19</a></p>
+<p id="n20" class="pln"><a href="#n20">20</a></p>
+<p id="n21" class="stm run hide_run"><a href="#n21">21</a></p>
+<p id="n22" class="pln"><a href="#n22">22</a></p>
+<p id="n23" class="stm run hide_run"><a href="#n23">23</a></p>
+<p id="n24" class="stm mis"><a href="#n24">24</a></p>
+<p id="n25" class="stm mis"><a href="#n25">25</a></p>
+<p id="n26" class="pln"><a href="#n26">26</a></p>
+<p id="n27" class="stm mis"><a href="#n27">27</a></p>
+<p id="n28" class="stm mis"><a href="#n28">28</a></p>
+<p id="n29" class="pln"><a href="#n29">29</a></p>
+<p id="n30" class="pln"><a href="#n30">30</a></p>
+<p id="n31" class="stm mis"><a href="#n31">31</a></p>
+<p id="n32" class="stm mis"><a href="#n32">32</a></p>
+<p id="n33" class="stm mis"><a href="#n33">33</a></p>
+<p id="n34" class="pln"><a href="#n34">34</a></p>
+<p id="n35" class="pln"><a href="#n35">35</a></p>
+<p id="n36" class="stm mis"><a href="#n36">36</a></p>
+<p id="n37" class="stm mis"><a href="#n37">37</a></p>
+<p id="n38" class="pln"><a href="#n38">38</a></p>
+<p id="n39" class="pln"><a href="#n39">39</a></p>
+<p id="n40" class="stm mis"><a href="#n40">40</a></p>
+<p id="n41" class="stm mis"><a href="#n41">41</a></p>
+<p id="n42" class="pln"><a href="#n42">42</a></p>
+<p id="n43" class="stm mis"><a href="#n43">43</a></p>
+<p id="n44" class="stm mis"><a href="#n44">44</a></p>
+<p id="n45" class="pln"><a href="#n45">45</a></p>
+<p id="n46" class="pln"><a href="#n46">46</a></p>
+<p id="n47" class="stm mis"><a href="#n47">47</a></p>
+<p id="n48" class="stm mis"><a href="#n48">48</a></p>
+<p id="n49" class="pln"><a href="#n49">49</a></p>
+<p id="n50" class="stm mis"><a href="#n50">50</a></p>
+<p id="n51" class="stm mis"><a href="#n51">51</a></p>
+<p id="n52" class="pln"><a href="#n52">52</a></p>
+<p id="n53" class="pln"><a href="#n53">53</a></p>
+<p id="n54" class="pln"><a href="#n54">54</a></p>
+<p id="n55" class="pln"><a href="#n55">55</a></p>
+<p id="n56" class="stm mis"><a href="#n56">56</a></p>
+<p id="n57" class="stm mis"><a href="#n57">57</a></p>
+<p id="n58" class="pln"><a href="#n58">58</a></p>
+<p id="n59" class="pln"><a href="#n59">59</a></p>
+<p id="n60" class="stm run hide_run"><a href="#n60">60</a></p>
+<p id="n61" class="pln"><a href="#n61">61</a></p>
+<p id="n62" class="pln"><a href="#n62">62</a></p>
+<p id="n63" class="pln"><a href="#n63">63</a></p>
+<p id="n64" class="pln"><a href="#n64">64</a></p>
+<p id="n65" class="pln"><a href="#n65">65</a></p>
+<p id="n66" class="pln"><a href="#n66">66</a></p>
+<p id="n67" class="pln"><a href="#n67">67</a></p>
+<p id="n68" class="pln"><a href="#n68">68</a></p>
+<p id="n69" class="pln"><a href="#n69">69</a></p>
+<p id="n70" class="stm run hide_run"><a href="#n70">70</a></p>
+<p id="n71" class="stm run hide_run"><a href="#n71">71</a></p>
+<p id="n72" class="pln"><a href="#n72">72</a></p>
+<p id="n73" class="stm run hide_run"><a href="#n73">73</a></p>
+<p id="n74" class="stm run hide_run"><a href="#n74">74</a></p>
+<p id="n75" class="stm run hide_run"><a href="#n75">75</a></p>
+<p id="n76" class="pln"><a href="#n76">76</a></p>
+<p id="n77" class="pln"><a href="#n77">77</a></p>
+<p id="n78" class="stm run hide_run"><a href="#n78">78</a></p>
+<p id="n79" class="stm run hide_run"><a href="#n79">79</a></p>
+<p id="n80" class="stm mis"><a href="#n80">80</a></p>
+<p id="n81" class="pln"><a href="#n81">81</a></p>
+<p id="n82" class="pln"><a href="#n82">82</a></p>
+<p id="n83" class="stm run hide_run"><a href="#n83">83</a></p>
+<p id="n84" class="pln"><a href="#n84">84</a></p>
+<p id="n85" class="pln"><a href="#n85">85</a></p>
+<p id="n86" class="stm run hide_run"><a href="#n86">86</a></p>
+<p id="n87" class="stm run hide_run"><a href="#n87">87</a></p>
+<p id="n88" class="pln"><a href="#n88">88</a></p>
+<p id="n89" class="stm run hide_run"><a href="#n89">89</a></p>
+<p id="n90" class="stm run hide_run"><a href="#n90">90</a></p>
+<p id="n91" class="stm run hide_run"><a href="#n91">91</a></p>
+<p id="n92" class="pln"><a href="#n92">92</a></p>
+<p id="n93" class="pln"><a href="#n93">93</a></p>
+<p id="n94" class="stm run hide_run"><a href="#n94">94</a></p>
+<p id="n95" class="stm run hide_run"><a href="#n95">95</a></p>
+<p id="n96" class="pln"><a href="#n96">96</a></p>
+<p id="n97" class="stm run hide_run"><a href="#n97">97</a></p>
+<p id="n98" class="stm run hide_run"><a href="#n98">98</a></p>
+<p id="n99" class="stm run hide_run"><a href="#n99">99</a></p>
+<p id="n100" class="stm run hide_run"><a href="#n100">100</a></p>
+<p id="n101" class="pln"><a href="#n101">101</a></p>
+<p id="n102" class="stm run hide_run"><a href="#n102">102</a></p>
+<p id="n103" class="stm run hide_run"><a href="#n103">103</a></p>
+<p id="n104" class="stm mis"><a href="#n104">104</a></p>
+<p id="n105" class="pln"><a href="#n105">105</a></p>
+<p id="n106" class="pln"><a href="#n106">106</a></p>
+<p id="n107" class="pln"><a href="#n107">107</a></p>
+<p id="n108" class="pln"><a href="#n108">108</a></p>
+<p id="n109" class="stm mis"><a href="#n109">109</a></p>
+<p id="n110" class="stm mis"><a href="#n110">110</a></p>
+<p id="n111" class="pln"><a href="#n111">111</a></p>
+<p id="n112" class="pln"><a href="#n112">112</a></p>
+<p id="n113" class="pln"><a href="#n113">113</a></p>
+<p id="n114" class="stm mis"><a href="#n114">114</a></p>
+<p id="n115" class="pln"><a href="#n115">115</a></p>
+<p id="n116" class="stm run hide_run"><a href="#n116">116</a></p>
+<p id="n117" class="pln"><a href="#n117">117</a></p>
+<p id="n118" class="stm run hide_run"><a href="#n118">118</a></p>
+<p id="n119" class="pln"><a href="#n119">119</a></p>
+<p id="n120" class="pln"><a href="#n120">120</a></p>
+<p id="n121" class="stm run hide_run"><a href="#n121">121</a></p>
+<p id="n122" class="pln"><a href="#n122">122</a></p>
+<p id="n123" class="pln"><a href="#n123">123</a></p>
+<p id="n124" class="stm run hide_run"><a href="#n124">124</a></p>
+<p id="n125" class="stm mis"><a href="#n125">125</a></p>
+<p id="n126" class="pln"><a href="#n126">126</a></p>
+<p id="n127" class="stm run hide_run"><a href="#n127">127</a></p>
+<p id="n128" class="pln"><a href="#n128">128</a></p>
+<p id="n129" class="pln"><a href="#n129">129</a></p>
+<p id="n130" class="stm run hide_run"><a href="#n130">130</a></p>
+<p id="n131" class="stm run hide_run"><a href="#n131">131</a></p>
+<p id="n132" class="stm run hide_run"><a href="#n132">132</a></p>
+<p id="n133" class="stm run hide_run"><a href="#n133">133</a></p>
+<p id="n134" class="pln"><a href="#n134">134</a></p>
+<p id="n135" class="pln"><a href="#n135">135</a></p>
+<p id="n136" class="stm run hide_run"><a href="#n136">136</a></p>
+<p id="n137" class="pln"><a href="#n137">137</a></p>
+<p id="n138" class="pln"><a href="#n138">138</a></p>
+<p id="n139" class="stm run hide_run"><a href="#n139">139</a></p>
+<p id="n140" class="stm run hide_run"><a href="#n140">140</a></p>
+<p id="n141" class="pln"><a href="#n141">141</a></p>
+<p id="n142" class="pln"><a href="#n142">142</a></p>
+<p id="n143" class="stm run hide_run"><a href="#n143">143</a></p>
+<p id="n144" class="stm run hide_run"><a href="#n144">144</a></p>
+<p id="n145" class="stm run hide_run"><a href="#n145">145</a></p>
+<p id="n146" class="stm run hide_run"><a href="#n146">146</a></p>
+<p id="n147" class="pln"><a href="#n147">147</a></p>
+<p id="n148" class="pln"><a href="#n148">148</a></p>
+<p id="n149" class="pln"><a href="#n149">149</a></p>
+<p id="n150" class="pln"><a href="#n150">150</a></p>
+<p id="n151" class="stm run hide_run"><a href="#n151">151</a></p>
+<p id="n152" class="stm run hide_run"><a href="#n152">152</a></p>
+<p id="n153" class="stm mis"><a href="#n153">153</a></p>
+<p id="n154" class="stm mis"><a href="#n154">154</a></p>
+<p id="n155" class="stm run hide_run"><a href="#n155">155</a></p>
+<p id="n156" class="stm run hide_run"><a href="#n156">156</a></p>
+<p id="n157" class="stm mis"><a href="#n157">157</a></p>
+<p id="n158" class="stm mis"><a href="#n158">158</a></p>
+<p id="n159" class="pln"><a href="#n159">159</a></p>
+<p id="n160" class="stm run hide_run"><a href="#n160">160</a></p>
+
+            </td>
+            <td class="text">
+<p id="t1" class="stm run hide_run"><span class="key">import</span> <span class="nam">csv</span><span class="strut">&nbsp;</span></p>
+<p id="t2" class="stm run hide_run"><span class="key">import</span> <span class="nam">os</span><span class="strut">&nbsp;</span></p>
+<p id="t3" class="stm run hide_run"><span class="key">import</span> <span class="nam">shutil</span><span class="strut">&nbsp;</span></p>
+<p id="t4" class="stm run hide_run"><span class="key">from</span> <span class="nam">shutil</span> <span class="key">import</span> <span class="nam">copyfile</span><span class="strut">&nbsp;</span></p>
+<p id="t5" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t6" class="stm run hide_run"><span class="key">import</span> <span class="nam">bagit</span><span class="strut">&nbsp;</span></p>
+<p id="t7" class="stm run hide_run"><span class="key">import</span> <span class="nam">boto3</span><span class="strut">&nbsp;</span></p>
+<p id="t8" class="stm run hide_run"><span class="key">from</span> <span class="nam">django</span><span class="op">.</span><span class="nam">conf</span> <span class="key">import</span> <span class="nam">settings</span><span class="strut">&nbsp;</span></p>
+<p id="t9" class="stm run hide_run"><span class="key">from</span> <span class="nam">django</span><span class="op">.</span><span class="nam">http</span> <span class="key">import</span> <span class="nam">HttpResponse</span><span class="strut">&nbsp;</span></p>
+<p id="t10" class="stm run hide_run"><span class="key">from</span> <span class="nam">django</span><span class="op">.</span><span class="nam">views</span><span class="op">.</span><span class="nam">generic</span> <span class="key">import</span> <span class="nam">TemplateView</span><span class="strut">&nbsp;</span></p>
+<p id="t11" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t12" class="stm run hide_run"><span class="key">from</span> <span class="nam">concordia</span><span class="op">.</span><span class="nam">models</span> <span class="key">import</span> <span class="nam">Collection</span><span class="op">,</span> <span class="nam">Transcription</span><span class="op">,</span> <span class="nam">UserAssetTagCollection</span><span class="strut">&nbsp;</span></p>
+<p id="t13" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t14" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t15" class="stm run hide_run"><span class="key">class</span> <span class="nam">ExportCollectionToCSV</span><span class="op">(</span><span class="nam">TemplateView</span><span class="op">)</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t16" class="pln">    <span class="str">"""</span><span class="strut">&nbsp;</span></p>
+<p id="t17" class="pln"><span class="str">    Exports the transcription and tags to csv file</span><span class="strut">&nbsp;</span></p>
+<p id="t18" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t19" class="pln"><span class="str">    """</span><span class="strut">&nbsp;</span></p>
+<p id="t20" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t21" class="stm run hide_run">    <span class="nam">template_name</span> <span class="op">=</span> <span class="str">"transcriptions/collection.html"</span><span class="strut">&nbsp;</span></p>
+<p id="t22" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t23" class="stm run hide_run">    <span class="key">def</span> <span class="nam">get</span><span class="op">(</span><span class="nam">self</span><span class="op">,</span> <span class="nam">request</span><span class="op">,</span> <span class="op">*</span><span class="nam">args</span><span class="op">,</span> <span class="op">**</span><span class="nam">kwargs</span><span class="op">)</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t24" class="stm mis">        <span class="nam">collection</span> <span class="op">=</span> <span class="nam">Collection</span><span class="op">.</span><span class="nam">objects</span><span class="op">.</span><span class="nam">get</span><span class="op">(</span><span class="nam">slug</span><span class="op">=</span><span class="nam">self</span><span class="op">.</span><span class="nam">args</span><span class="op">[</span><span class="num">0</span><span class="op">]</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t25" class="stm mis">        <span class="nam">asset_list</span> <span class="op">=</span> <span class="nam">collection</span><span class="op">.</span><span class="nam">asset_set</span><span class="op">.</span><span class="nam">all</span><span class="op">(</span><span class="op">)</span><span class="op">.</span><span class="nam">order_by</span><span class="op">(</span><span class="str">"title"</span><span class="op">,</span> <span class="str">"sequence"</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t26" class="pln">        <span class="com"># Create the HttpResponse object with the appropriate CSV header.</span><span class="strut">&nbsp;</span></p>
+<p id="t27" class="stm mis">        <span class="nam">response</span> <span class="op">=</span> <span class="nam">HttpResponse</span><span class="op">(</span><span class="nam">content_type</span><span class="op">=</span><span class="str">"text/csv"</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t28" class="stm mis">        <span class="nam">response</span><span class="op">[</span><span class="str">"Content-Disposition"</span><span class="op">]</span> <span class="op">=</span> <span class="str">'attachment; filename="{0}.csv"'</span><span class="op">.</span><span class="nam">format</span><span class="op">(</span><span class="strut">&nbsp;</span></p>
+<p id="t29" class="pln">            <span class="nam">collection</span><span class="op">.</span><span class="nam">slug</span><span class="strut">&nbsp;</span></p>
+<p id="t30" class="pln">        <span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t31" class="stm mis">        <span class="nam">field_names</span> <span class="op">=</span> <span class="op">[</span><span class="str">"title"</span><span class="op">,</span> <span class="str">"description"</span><span class="op">,</span> <span class="str">"media_url"</span><span class="op">]</span><span class="strut">&nbsp;</span></p>
+<p id="t32" class="stm mis">        <span class="nam">writer</span> <span class="op">=</span> <span class="nam">csv</span><span class="op">.</span><span class="nam">writer</span><span class="op">(</span><span class="nam">response</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t33" class="stm mis">        <span class="nam">writer</span><span class="op">.</span><span class="nam">writerow</span><span class="op">(</span><span class="strut">&nbsp;</span></p>
+<p id="t34" class="pln">            <span class="op">[</span><span class="str">"Collection"</span><span class="op">,</span> <span class="str">"Title"</span><span class="op">,</span> <span class="str">"Description"</span><span class="op">,</span> <span class="str">"MediaUrl"</span><span class="op">,</span> <span class="str">"Transcription"</span><span class="op">,</span> <span class="str">"Tags"</span><span class="op">]</span><span class="strut">&nbsp;</span></p>
+<p id="t35" class="pln">        <span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t36" class="stm mis">        <span class="key">for</span> <span class="nam">asset</span> <span class="key">in</span> <span class="nam">asset_list</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t37" class="stm mis">            <span class="nam">transcription</span> <span class="op">=</span> <span class="nam">Transcription</span><span class="op">.</span><span class="nam">objects</span><span class="op">.</span><span class="nam">filter</span><span class="op">(</span><span class="strut">&nbsp;</span></p>
+<p id="t38" class="pln">                <span class="nam">asset</span><span class="op">=</span><span class="nam">asset</span><span class="op">,</span> <span class="nam">user_id</span><span class="op">=</span><span class="nam">self</span><span class="op">.</span><span class="nam">request</span><span class="op">.</span><span class="nam">user</span><span class="op">.</span><span class="nam">id</span><span class="strut">&nbsp;</span></p>
+<p id="t39" class="pln">            <span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t40" class="stm mis">            <span class="key">if</span> <span class="nam">transcription</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t41" class="stm mis">                <span class="nam">transcription</span> <span class="op">=</span> <span class="nam">transcription</span><span class="op">[</span><span class="num">0</span><span class="op">]</span><span class="op">.</span><span class="nam">text</span><span class="strut">&nbsp;</span></p>
+<p id="t42" class="pln">            <span class="key">else</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t43" class="stm mis">                <span class="nam">transcription</span> <span class="op">=</span> <span class="str">""</span><span class="strut">&nbsp;</span></p>
+<p id="t44" class="stm mis">            <span class="nam">tags</span> <span class="op">=</span> <span class="nam">UserAssetTagCollection</span><span class="op">.</span><span class="nam">objects</span><span class="op">.</span><span class="nam">filter</span><span class="op">(</span><span class="strut">&nbsp;</span></p>
+<p id="t45" class="pln">                <span class="nam">asset</span><span class="op">=</span><span class="nam">asset</span><span class="op">,</span> <span class="nam">user_id</span><span class="op">=</span><span class="nam">self</span><span class="op">.</span><span class="nam">request</span><span class="op">.</span><span class="nam">user</span><span class="op">.</span><span class="nam">id</span><span class="strut">&nbsp;</span></p>
+<p id="t46" class="pln">            <span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t47" class="stm mis">            <span class="key">if</span> <span class="nam">tags</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t48" class="stm mis">                <span class="nam">tags</span> <span class="op">=</span> <span class="nam">list</span><span class="op">(</span><span class="nam">tags</span><span class="op">[</span><span class="num">0</span><span class="op">]</span><span class="op">.</span><span class="nam">tags</span><span class="op">.</span><span class="nam">all</span><span class="op">(</span><span class="op">)</span><span class="op">.</span><span class="nam">values_list</span><span class="op">(</span><span class="str">"name"</span><span class="op">,</span> <span class="nam">flat</span><span class="op">=</span><span class="key">True</span><span class="op">)</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t49" class="pln">            <span class="key">else</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t50" class="stm mis">                <span class="nam">tags</span> <span class="op">=</span> <span class="str">""</span><span class="strut">&nbsp;</span></p>
+<p id="t51" class="stm mis">            <span class="nam">row</span> <span class="op">=</span> <span class="op">(</span><span class="strut">&nbsp;</span></p>
+<p id="t52" class="pln">                <span class="op">[</span><span class="nam">collection</span><span class="op">.</span><span class="nam">title</span><span class="op">]</span><span class="strut">&nbsp;</span></p>
+<p id="t53" class="pln">                <span class="op">+</span> <span class="op">[</span><span class="nam">getattr</span><span class="op">(</span><span class="nam">asset</span><span class="op">,</span> <span class="nam">i</span><span class="op">)</span> <span class="key">for</span> <span class="nam">i</span> <span class="key">in</span> <span class="nam">field_names</span><span class="op">]</span><span class="strut">&nbsp;</span></p>
+<p id="t54" class="pln">                <span class="op">+</span> <span class="op">[</span><span class="nam">transcription</span><span class="op">,</span> <span class="nam">tags</span><span class="op">]</span><span class="strut">&nbsp;</span></p>
+<p id="t55" class="pln">            <span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t56" class="stm mis">            <span class="nam">writer</span><span class="op">.</span><span class="nam">writerow</span><span class="op">(</span><span class="nam">row</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t57" class="stm mis">        <span class="key">return</span> <span class="nam">response</span><span class="strut">&nbsp;</span></p>
+<p id="t58" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t59" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t60" class="stm run hide_run"><span class="key">class</span> <span class="nam">ExportCollectionToBagit</span><span class="op">(</span><span class="nam">TemplateView</span><span class="op">)</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t61" class="pln">    <span class="str">"""</span><span class="strut">&nbsp;</span></p>
+<p id="t62" class="pln"><span class="str">    Creates temp directory structure for source data.  Copies source image</span><span class="strut">&nbsp;</span></p>
+<p id="t63" class="pln"><span class="str">    file from S3 or local storage into temp directory, builds export.csv</span><span class="strut">&nbsp;</span></p>
+<p id="t64" class="pln"><span class="str">    with meta, transcription, and tag data.  Executes bagit.py to turn temp</span><span class="strut">&nbsp;</span></p>
+<p id="t65" class="pln"><span class="str">    directory into bagit strucutre.  Builds and exports bagit structure as</span><span class="strut">&nbsp;</span></p>
+<p id="t66" class="pln"><span class="str">    zip.  Removes all temporary directories and files.</span><span class="strut">&nbsp;</span></p>
+<p id="t67" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t68" class="pln"><span class="str">    """</span><span class="strut">&nbsp;</span></p>
+<p id="t69" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t70" class="stm run hide_run">    <span class="nam">include_images</span> <span class="op">=</span> <span class="key">True</span><span class="strut">&nbsp;</span></p>
+<p id="t71" class="stm run hide_run">    <span class="nam">template_name</span> <span class="op">=</span> <span class="str">"transcriptions/collection.html"</span><span class="strut">&nbsp;</span></p>
+<p id="t72" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t73" class="stm run hide_run">    <span class="key">def</span> <span class="nam">get</span><span class="op">(</span><span class="nam">self</span><span class="op">,</span> <span class="nam">request</span><span class="op">,</span> <span class="op">*</span><span class="nam">args</span><span class="op">,</span> <span class="op">**</span><span class="nam">kwargs</span><span class="op">)</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t74" class="stm run hide_run">        <span class="nam">collection</span> <span class="op">=</span> <span class="nam">Collection</span><span class="op">.</span><span class="nam">objects</span><span class="op">.</span><span class="nam">get</span><span class="op">(</span><span class="nam">slug</span><span class="op">=</span><span class="nam">self</span><span class="op">.</span><span class="nam">args</span><span class="op">[</span><span class="num">0</span><span class="op">]</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t75" class="stm run hide_run">        <span class="nam">asset_list</span> <span class="op">=</span> <span class="nam">collection</span><span class="op">.</span><span class="nam">asset_set</span><span class="op">.</span><span class="nam">all</span><span class="op">(</span><span class="op">)</span><span class="op">.</span><span class="nam">order_by</span><span class="op">(</span><span class="str">"title"</span><span class="op">,</span> <span class="str">"sequence"</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t76" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t77" class="pln">        <span class="com"># Make sure export folder exists (media/exporter)</span><span class="strut">&nbsp;</span></p>
+<p id="t78" class="stm run hide_run">        <span class="nam">export_folder</span> <span class="op">=</span> <span class="str">"%s/exporter"</span> <span class="op">%</span> <span class="op">(</span><span class="nam">settings</span><span class="op">.</span><span class="nam">MEDIA_ROOT</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t79" class="stm run hide_run">        <span class="key">if</span> <span class="key">not</span> <span class="nam">os</span><span class="op">.</span><span class="nam">path</span><span class="op">.</span><span class="nam">exists</span><span class="op">(</span><span class="nam">export_folder</span><span class="op">)</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t80" class="stm mis">            <span class="nam">os</span><span class="op">.</span><span class="nam">makedirs</span><span class="op">(</span><span class="nam">export_folder</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t81" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t82" class="pln">        <span class="com"># Create temp exporter folder structure in media for bagit</span><span class="strut">&nbsp;</span></p>
+<p id="t83" class="stm run hide_run">        <span class="nam">collection_folder</span> <span class="op">=</span> <span class="str">"%s/exporter/%s"</span> <span class="op">%</span> <span class="op">(</span><span class="nam">settings</span><span class="op">.</span><span class="nam">MEDIA_ROOT</span><span class="op">,</span> <span class="nam">collection</span><span class="op">.</span><span class="nam">slug</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t84" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t85" class="pln">        <span class="com"># Create collection folder (media/exporter/&lt;collection>)</span><span class="strut">&nbsp;</span></p>
+<p id="t86" class="stm run hide_run">        <span class="key">if</span> <span class="key">not</span> <span class="nam">os</span><span class="op">.</span><span class="nam">path</span><span class="op">.</span><span class="nam">exists</span><span class="op">(</span><span class="nam">collection_folder</span><span class="op">)</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t87" class="stm run hide_run">            <span class="nam">os</span><span class="op">.</span><span class="nam">mkdir</span><span class="op">(</span><span class="nam">collection_folder</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t88" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t89" class="stm run hide_run">        <span class="key">for</span> <span class="nam">asset</span> <span class="key">in</span> <span class="nam">asset_list</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t90" class="stm run hide_run">            <span class="nam">item_folder_name</span> <span class="op">=</span> <span class="nam">asset</span><span class="op">.</span><span class="nam">media_url</span><span class="op">.</span><span class="nam">rsplit</span><span class="op">(</span><span class="str">"/"</span><span class="op">)</span><span class="op">[</span><span class="op">-</span><span class="num">2</span><span class="op">]</span><span class="strut">&nbsp;</span></p>
+<p id="t91" class="stm run hide_run">            <span class="nam">item_folder</span> <span class="op">=</span> <span class="str">"%s/%s"</span> <span class="op">%</span> <span class="op">(</span><span class="nam">collection_folder</span><span class="op">,</span> <span class="nam">item_folder_name</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t92" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t93" class="pln">            <span class="com"># Create asset folders (media/exporter/&lt;collection>/&lt;asset></span><span class="strut">&nbsp;</span></p>
+<p id="t94" class="stm run hide_run">            <span class="key">if</span> <span class="key">not</span> <span class="nam">os</span><span class="op">.</span><span class="nam">path</span><span class="op">.</span><span class="nam">exists</span><span class="op">(</span><span class="nam">item_folder</span><span class="op">)</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t95" class="stm run hide_run">                <span class="nam">os</span><span class="op">.</span><span class="nam">mkdir</span><span class="op">(</span><span class="nam">item_folder</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t96" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t97" class="stm run hide_run">            <span class="nam">src_folder</span> <span class="op">=</span> <span class="nam">item_folder</span><span class="op">.</span><span class="nam">replace</span><span class="op">(</span><span class="str">"exporter/"</span><span class="op">,</span> <span class="str">""</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t98" class="stm run hide_run">            <span class="nam">src_name</span> <span class="op">=</span> <span class="nam">asset</span><span class="op">.</span><span class="nam">media_url</span><span class="op">.</span><span class="nam">rsplit</span><span class="op">(</span><span class="str">"/"</span><span class="op">)</span><span class="op">[</span><span class="op">-</span><span class="num">1</span><span class="op">]</span><span class="strut">&nbsp;</span></p>
+<p id="t99" class="stm run hide_run">            <span class="nam">src_root</span> <span class="op">=</span> <span class="nam">src_name</span><span class="op">.</span><span class="nam">rsplit</span><span class="op">(</span><span class="str">"."</span><span class="op">)</span><span class="op">[</span><span class="num">0</span><span class="op">]</span><span class="strut">&nbsp;</span></p>
+<p id="t100" class="stm run hide_run">            <span class="nam">dest</span> <span class="op">=</span> <span class="str">"%s/%s"</span> <span class="op">%</span> <span class="op">(</span><span class="nam">item_folder</span><span class="op">,</span> <span class="nam">src_name</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t101" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t102" class="stm run hide_run">            <span class="key">if</span> <span class="nam">self</span><span class="op">.</span><span class="nam">include_images</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t103" class="stm run hide_run">                <span class="key">if</span> <span class="nam">collection</span><span class="op">.</span><span class="nam">s3_storage</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t104" class="stm mis">                    <span class="nam">s3</span> <span class="op">=</span> <span class="nam">boto3</span><span class="op">.</span><span class="nam">client</span><span class="op">(</span><span class="strut">&nbsp;</span></p>
+<p id="t105" class="pln">                        <span class="str">"s3"</span><span class="op">,</span><span class="strut">&nbsp;</span></p>
+<p id="t106" class="pln">                        <span class="nam">aws_access_key_id</span><span class="op">=</span><span class="nam">settings</span><span class="op">.</span><span class="nam">AWS_S3</span><span class="op">[</span><span class="str">"AWS_ACCESS_KEY_ID"</span><span class="op">]</span><span class="op">,</span><span class="strut">&nbsp;</span></p>
+<p id="t107" class="pln">                        <span class="nam">aws_secret_access_key</span><span class="op">=</span><span class="nam">settings</span><span class="op">.</span><span class="nam">AWS_S3</span><span class="op">[</span><span class="str">"AWS_SECRET_ACCESS_KEY"</span><span class="op">]</span><span class="op">,</span><span class="strut">&nbsp;</span></p>
+<p id="t108" class="pln">                    <span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t109" class="stm mis">                    <span class="nam">bucket_name</span> <span class="op">=</span> <span class="nam">settings</span><span class="op">.</span><span class="nam">AWS_S3</span><span class="op">[</span><span class="str">"S3_COLLECTION_BUCKET"</span><span class="op">]</span><span class="strut">&nbsp;</span></p>
+<p id="t110" class="stm mis">                    <span class="nam">s3_path</span> <span class="op">=</span> <span class="str">"{0}/{1}/{2}"</span><span class="op">.</span><span class="nam">format</span><span class="op">(</span><span class="strut">&nbsp;</span></p>
+<p id="t111" class="pln">                        <span class="nam">collection</span><span class="op">.</span><span class="nam">slug</span><span class="op">,</span> <span class="nam">item_folder_name</span><span class="op">,</span> <span class="nam">src_name</span><span class="strut">&nbsp;</span></p>
+<p id="t112" class="pln">                    <span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t113" class="pln">                    <span class="com"># Copy asset image from S3 into temp asset folder</span><span class="strut">&nbsp;</span></p>
+<p id="t114" class="stm mis">                    <span class="nam">s3</span><span class="op">.</span><span class="nam">download_file</span><span class="op">(</span><span class="nam">bucket_name</span><span class="op">,</span> <span class="nam">s3_path</span><span class="op">,</span> <span class="nam">dest</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t115" class="pln">                <span class="key">else</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t116" class="stm run hide_run">                    <span class="nam">src</span> <span class="op">=</span> <span class="str">"%s/%s"</span> <span class="op">%</span> <span class="op">(</span><span class="nam">src_folder</span><span class="op">,</span> <span class="nam">src_name</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t117" class="pln">                    <span class="com"># Copy asset image from local storage into temp asset folder</span><span class="strut">&nbsp;</span></p>
+<p id="t118" class="stm run hide_run">                    <span class="nam">copyfile</span><span class="op">(</span><span class="nam">src</span><span class="op">,</span> <span class="nam">dest</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t119" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t120" class="pln">            <span class="com"># Get transcription data</span><span class="strut">&nbsp;</span></p>
+<p id="t121" class="stm run hide_run">            <span class="nam">transcription</span> <span class="op">=</span> <span class="nam">Transcription</span><span class="op">.</span><span class="nam">objects</span><span class="op">.</span><span class="nam">filter</span><span class="op">(</span><span class="strut">&nbsp;</span></p>
+<p id="t122" class="pln">                <span class="nam">asset</span><span class="op">=</span><span class="nam">asset</span><span class="op">,</span> <span class="nam">user_id</span><span class="op">=</span><span class="nam">self</span><span class="op">.</span><span class="nam">request</span><span class="op">.</span><span class="nam">user</span><span class="op">.</span><span class="nam">id</span><span class="strut">&nbsp;</span></p>
+<p id="t123" class="pln">            <span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t124" class="stm run hide_run">            <span class="key">if</span> <span class="nam">transcription</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t125" class="stm mis">                <span class="nam">transcription</span> <span class="op">=</span> <span class="nam">transcription</span><span class="op">[</span><span class="num">0</span><span class="op">]</span><span class="op">.</span><span class="nam">text</span><span class="strut">&nbsp;</span></p>
+<p id="t126" class="pln">            <span class="key">else</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t127" class="stm run hide_run">                <span class="nam">transcription</span> <span class="op">=</span> <span class="str">""</span><span class="strut">&nbsp;</span></p>
+<p id="t128" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t129" class="pln">            <span class="com"># Build transcription output text file</span><span class="strut">&nbsp;</span></p>
+<p id="t130" class="stm run hide_run">            <span class="nam">tran_output_path</span> <span class="op">=</span> <span class="str">"{0}/{1}.txt"</span><span class="op">.</span><span class="nam">format</span><span class="op">(</span><span class="nam">item_folder</span><span class="op">,</span> <span class="nam">src_root</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t131" class="stm run hide_run">            <span class="nam">tran_out_file</span> <span class="op">=</span> <span class="nam">open</span><span class="op">(</span><span class="nam">tran_output_path</span><span class="op">,</span> <span class="str">"w"</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t132" class="stm run hide_run">            <span class="nam">tran_out_file</span><span class="op">.</span><span class="nam">write</span><span class="op">(</span><span class="nam">transcription</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t133" class="stm run hide_run">            <span class="nam">tran_out_file</span><span class="op">.</span><span class="nam">close</span><span class="op">(</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t134" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t135" class="pln">        <span class="com"># Turn Structure into bagit format</span><span class="strut">&nbsp;</span></p>
+<p id="t136" class="stm run hide_run">        <span class="nam">bagit</span><span class="op">.</span><span class="nam">make_bag</span><span class="op">(</span><span class="nam">collection_folder</span><span class="op">,</span> <span class="op">{</span><span class="str">"Contact-Name"</span><span class="op">:</span> <span class="nam">request</span><span class="op">.</span><span class="nam">user</span><span class="op">.</span><span class="nam">username</span><span class="op">}</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t137" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t138" class="pln">        <span class="com"># Build .zipfile of bagit formatted Collection Folder</span><span class="strut">&nbsp;</span></p>
+<p id="t139" class="stm run hide_run">        <span class="nam">archive_name</span> <span class="op">=</span> <span class="nam">collection_folder</span><span class="strut">&nbsp;</span></p>
+<p id="t140" class="stm run hide_run">        <span class="nam">shutil</span><span class="op">.</span><span class="nam">make_archive</span><span class="op">(</span><span class="nam">archive_name</span><span class="op">,</span> <span class="str">"zip"</span><span class="op">,</span> <span class="nam">collection_folder</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t141" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t142" class="pln">        <span class="com"># Download zip</span><span class="strut">&nbsp;</span></p>
+<p id="t143" class="stm run hide_run">        <span class="key">with</span> <span class="nam">open</span><span class="op">(</span><span class="str">"%s.zip"</span> <span class="op">%</span> <span class="nam">collection_folder</span><span class="op">,</span> <span class="str">"rb"</span><span class="op">)</span> <span class="key">as</span> <span class="nam">file</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t144" class="stm run hide_run">            <span class="nam">outfile</span> <span class="op">=</span> <span class="nam">file</span><span class="op">.</span><span class="nam">read</span><span class="op">(</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t145" class="stm run hide_run">        <span class="nam">response</span> <span class="op">=</span> <span class="nam">HttpResponse</span><span class="op">(</span><span class="nam">outfile</span><span class="op">,</span> <span class="nam">content_type</span><span class="op">=</span><span class="str">"application/zip"</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t146" class="stm run hide_run">        <span class="nam">response</span><span class="op">[</span><span class="str">"Content-Disposition"</span><span class="op">]</span> <span class="op">=</span> <span class="op">(</span><span class="strut">&nbsp;</span></p>
+<p id="t147" class="pln">            <span class="str">"attachment; filename=%s.zip"</span> <span class="op">%</span> <span class="nam">collection</span><span class="op">.</span><span class="nam">slug</span><span class="strut">&nbsp;</span></p>
+<p id="t148" class="pln">        <span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t149" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t150" class="pln">        <span class="com"># Clean up temp folders &amp; zipfile once exported</span><span class="strut">&nbsp;</span></p>
+<p id="t151" class="stm run hide_run">        <span class="key">try</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t152" class="stm run hide_run">            <span class="nam">shutil</span><span class="op">.</span><span class="nam">rmtree</span><span class="op">(</span><span class="nam">collection_folder</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t153" class="stm mis">        <span class="key">except</span> <span class="nam">Exception</span> <span class="key">as</span> <span class="nam">e</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t154" class="stm mis">            <span class="key">pass</span><span class="strut">&nbsp;</span></p>
+<p id="t155" class="stm run hide_run">        <span class="key">try</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t156" class="stm run hide_run">            <span class="nam">os</span><span class="op">.</span><span class="nam">remove</span><span class="op">(</span><span class="str">"%s.zip"</span> <span class="op">%</span> <span class="nam">collection_folder</span><span class="op">)</span><span class="strut">&nbsp;</span></p>
+<p id="t157" class="stm mis">        <span class="key">except</span> <span class="nam">Exception</span> <span class="key">as</span> <span class="nam">e</span><span class="op">:</span><span class="strut">&nbsp;</span></p>
+<p id="t158" class="stm mis">            <span class="key">pass</span><span class="strut">&nbsp;</span></p>
+<p id="t159" class="pln"><span class="strut">&nbsp;</span></p>
+<p id="t160" class="stm run hide_run">        <span class="key">return</span> <span class="nam">response</span><span class="strut">&nbsp;</span></p>
+
+            </td>
+        </tr>
+    </table>
+</div>
+
+<div id="footer">
+    <div class="content">
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/coverage-5.0a1">coverage.py v5.0a1</a>,
+            created at 2018-08-15 09:38
+        </p>
+    </div>
+</div>
+
+</body>
+</html>

--- a/exporter/tests/test_view.py
+++ b/exporter/tests/test_view.py
@@ -130,15 +130,8 @@ class ViewTest_Exporter(TestCase):
             # self.assertIsNone(zipped_file.testzip())
             self.assertIn("bagit.txt", zipped_file.namelist())
             self.assertIn("bag-info.txt", zipped_file.namelist())
-            self.assertIn("data/testasset/export.csv", zipped_file.namelist())
+            self.assertIn("data/testasset/asset.txt", zipped_file.namelist())
 
-            csv_file = zipped_file.read("data/testasset/export.csv")
-            self.assertEqual(
-                str(csv_file),
-                "b'Collection,Title,Description,MediaUrl,Transcription,Tags\\r\\nFooCollection,TestAsset,Asset Description,{0},,\\r\\n'".format(
-                    media_url_str
-                ),  # noqa
-            )
         finally:
             zipped_file.close()
             f.close()

--- a/exporter/tests/test_view.py
+++ b/exporter/tests/test_view.py
@@ -51,56 +51,98 @@ class ViewTest_Exporter(TestCase):
         :return:
         """
 
-        media_url_str = "/foocollection/testasset/asset.jpg"
-        collection_name_str = "foocollection"
-        asset_folder_name_str = "testasset"
-        asset_name_str = "asset.jpg"
-
         # Arrange
         self.login_user()
 
-        # create a collection
-        self.collection = Collection(
-            title="FooCollection",
-            slug=collection_name_str,
+        ## Build test data for local storage collection ##
+        # Collection Info (local storage)
+        locstor_media_url_str = "/locstorcollection/testasset/asset.jpg"
+        locstor_collection_name_str = "locstorcollection"
+        locstor_asset_folder_name_str = "testasset"
+        locstor_asset_name_str = "asset.jpg"
+
+        # create a collection (local Storage)
+        self.collection1 = Collection(
+            title="LocStorCollection",
+            slug=locstor_collection_name_str,
             description="Collection Description",
             metadata={"key": "val1"},
             is_active=True,
             s3_storage=False,
             status=Status.EDIT,
         )
-        self.collection.save()
+        self.collection1.save()
 
-        # create an Asset
-        self.asset = Asset(
+        # create an Asset (local Storage)
+        self.asset1 = Asset(
             title="TestAsset",
-            slug=asset_folder_name_str,
+            slug=locstor_asset_folder_name_str,
             description="Asset Description",
-            media_url=media_url_str,
+            media_url=locstor_media_url_str,
             media_type=MediaType.IMAGE,
-            collection=self.collection,
+            collection=self.collection1,
             sequence=0,
             metadata={"key": "val2"},
             status=Status.EDIT,
         )
-        self.asset.save()
+        self.asset1.save()
 
         # add a Transcription object
-        self.transcription = Transcription(
-            asset=self.asset, user_id=self.user.id, status=Status.EDIT, text="Sample"
+        self.transcription1 = Transcription(
+            asset=self.asset1, user_id=self.user.id, status=Status.EDIT, text="Sample"
         )
-        self.transcription.save()
+        self.transcription1.save()
 
-        # Make sure correct folders structure exists
-        collection_folder = "{0}/{1}".format(settings.MEDIA_ROOT, collection_name_str)
+        ## Build test data for S3 Storage Collection ##
+        # Collection Info (S3 storage)
+        s3_media_url_str = "https://s3.us-east-2.amazonaws.com/chc-collections/test_s3/mss859430177/0.jpg"
+        s3_collection_name_str = "test_s3"
+        s3_asset_folder_name_str = "testasset"
+        s3_asset_name_str = "asset.jpg"
+
+        # create a collection (local Storage)
+        self.collection2 = Collection(
+            title="Test S3",
+            slug=s3_collection_name_str,
+            description="Collection Description",
+            metadata={"key": "val1"},
+            is_active=True,
+            s3_storage=True,
+            status=Status.EDIT,
+        )
+        self.collection2.save()
+
+        # create an Asset (local Storage)
+        self.asset2 = Asset(
+            title="TestAsset",
+            slug=s3_asset_folder_name_str,
+            description="Asset Description",
+            media_url=s3_media_url_str,
+            media_type=MediaType.IMAGE,
+            collection=self.collection2,
+            sequence=0,
+            metadata={"key": "val2"},
+            status=Status.EDIT,
+        )
+        self.asset2.save()
+
+        # add a Transcription object
+        self.transcription2 = Transcription(
+            asset=self.asset2, user_id=self.user.id, status=Status.EDIT, text="Sample"
+        )
+        self.transcription2.save()
+
+
+        # Make sure correct folders structure exists for Local Storage Collection
+        collection_folder = "{0}/{1}".format(settings.MEDIA_ROOT, locstor_collection_name_str)
         if not os.path.exists(collection_folder):
             os.makedirs(collection_folder)
-        source_dir = "{0}/{1}".format(collection_folder, asset_folder_name_str)
-        if not os.path.exists(source_dir):
-            os.makedirs(source_dir)
+        item_dir = "{0}/{1}".format(collection_folder, locstor_asset_folder_name_str)
+        if not os.path.exists(item_dir):
+            os.makedirs(item_dir)
 
-        # create source asset file
-        with open("{0}/{1}".format(source_dir, asset_name_str), "w+") as csv_file:
+        # create source asset file for Local Storage Collection
+        with open("{0}/{1}".format(item_dir, locstor_asset_name_str), "w+") as csv_file:
             writer = csv.writer(csv_file)
             writer.writerow(
                 [
@@ -113,15 +155,15 @@ class ViewTest_Exporter(TestCase):
                 ]
             )
 
-        # Act
-        response = self.client.get("/transcribe/exportBagit/foocollection/")
+        # Act (local storage collection)
+        response = self.client.get("/transcribe/exportBagit/locstorcollection/")
 
-        # Assert
+        # Assert for Local Storage Collection
 
         self.assertEqual(response.status_code, 200)
         self.assertEquals(
             response.get("Content-Disposition"),
-            "attachment; filename=foocollection.zip",
+            "attachment; filename=locstorcollection.zip",
         )
         try:
             f = io.BytesIO(response.content)
@@ -135,6 +177,31 @@ class ViewTest_Exporter(TestCase):
         finally:
             zipped_file.close()
             f.close()
+
+
+        # Act (s3 collection)
+        response2 = self.client.get("/transcribe/exportBagit/test_s3/")
+
+        # Assert for s3 Collection
+
+        self.assertEqual(response2.status_code, 200)
+        self.assertEquals(
+            response2.get("Content-Disposition"),
+            "attachment; filename=test_s3.zip",
+        )
+        try:
+            f = io.BytesIO(response2.content)
+            zipped_file = zipfile.ZipFile(f, "r")
+
+            self.assertIn("bagit.txt", zipped_file.namelist())
+            self.assertIn("bag-info.txt", zipped_file.namelist())
+            self.assertIn("data/mss859430177/0.txt", zipped_file.namelist())
+            self.assertIn("data/mss859430177/0.jpg", zipped_file.namelist())
+
+        finally:
+            zipped_file.close()
+            f.close()
+
 
         # Clean up temp folders
         try:

--- a/exporter/tests/test_view.py
+++ b/exporter/tests/test_view.py
@@ -147,6 +147,7 @@ class AWS_S3_ConnectionTest(TestCase):
     """
     This class contains the test for the AWS S3 Connection
     """
+
     def test_connection(self):
         connection = boto3.client(
             "s3",

--- a/exporter/views.py
+++ b/exporter/views.py
@@ -118,11 +118,11 @@ class ExportCollectionToBagit(TemplateView):
                     copyfile(src, dest)
 
             # Get transcription data
-            transcription = Transcription.objects.filter(
+            transcription_obj = Transcription.objects.filter(
                 asset=asset, user_id=self.request.user.id
             )
-            if transcription:
-                transcription = transcription[0].text
+            if transcription_obj:
+                transcription = transcription_obj[0].text
             else:
                 transcription = ""
 


### PR DESCRIPTION
This pull request (CHC-347)

- Changes the ExportToBagit class to export .txt files for transcriptions
- Changes the ExportToBagit class to no longer export tags
- Changes the ExportToBagit class to no longer export .csv files
- Modifies Tests to work with the new .txt export
- Modifies populate_db.py script to build a collection with multiple items
- Adds a flag for include_images.  This flag is only supported on the back end.  There is no UI yet to let the user choose to include or exclude images.  The default value for this flag is include_images = True

The importer does not yet support AWS S3 Storage therefore testing this pull request requires you to create a mock collection using AWS S3 Storage.

To add the Test S3 collection you will need to configure django settings and then execute the populate_db script. If you have any questions or need help adding the test collection please contact me directly.

```
$ export DJANGO_SETTINGS_MODULE="concordia.settings_dev"
$ ./manage.py populate_db
```

You will need to test that the ExportToBagit function works with existing local storage collections as well as the mock AWS S3 storage collection.

- Temporary ec2 instance for test can be found here: http://18.188.3.4/transcribe/
- AWS Key Info for the .env file can be found here: https://artemisconsulting.atlassian.net/wiki/spaces/CHC/pages/47972353/Configuration+Information