### PR TITLE
Avoid subrequests in views

### DIFF
--- a/concordia/views.py
+++ b/concordia/views.py
@@ -10,8 +10,7 @@ import requests
 from captcha.fields import CaptchaField
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth import get_user_model
-from django.contrib.auth import update_session_auth_hash
+from django.contrib.auth import get_user_model, update_session_auth_hash
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.models import User
 from django.core.mail import send_mail
@@ -23,13 +22,25 @@ from django.template import loader
 from django.urls import reverse
 from django.views.generic import FormView, TemplateView, View
 from registration.backends.hmac.views import RegistrationView
-from rest_framework import status, generics
+from rest_framework import generics, status
 from rest_framework.test import APIRequestFactory
 
-from concordia.forms import (CaptchaEmbedForm, ConcordiaContactUsForm,
-                             ConcordiaUserEditForm, ConcordiaUserForm)
-from concordia.models import (Asset, Project, Item, Campaign, PageInUse, Status, Transcription,
-                              UserProfile)
+from concordia.forms import (
+    CaptchaEmbedForm,
+    ConcordiaContactUsForm,
+    ConcordiaUserEditForm,
+    ConcordiaUserForm,
+)
+from concordia.models import (
+    Asset,
+    Campaign,
+    Item,
+    PageInUse,
+    Project,
+    Status,
+    Transcription,
+    UserProfile,
+)
 from concordia.views_ws import PageInUseCreate
 from importer.views import CreateCampaignView
 
@@ -58,8 +69,7 @@ def get_anonymous_user(request, user_id=True):
     :return: User id or User
     """
     response = requests.get(
-        "%s://%s/ws/anonymous_user/"
-        % (request.scheme, request.get_host()),
+        "%s://%s/ws/anonymous_user/" % (request.scheme, request.get_host()),
         cookies=request.COOKIES,
     )
     anonymous_json_val = json.loads(response.content.decode("utf-8"))
@@ -85,7 +95,10 @@ class AccountProfileView(LoginRequiredMixin, TemplateView):
         if form.is_valid():
             obj = form.save(commit=True)
             obj.id = self.request.user.id
-            if "password1" not in self.request.POST and "password2" not in self.request.POST:
+            if (
+                "password1" not in self.request.POST
+                and "password2" not in self.request.POST
+            ):
                 obj.password = self.request.user.password
             else:
                 update_session_auth_hash(self.request, obj)
@@ -195,8 +208,11 @@ class ConcordiaCampaignView(TemplateView):
         items = paginator.get_page(page)
 
         return dict(
-            super().get_context_data(**kws), campaign=campaign_json_val, projects=project_sorted_list
+            super().get_context_data(**kws),
+            campaign=campaign_json_val,
+            projects=project_sorted_list,
         )
+
 
 class ConcordiaProjectView(TemplateView):
     template_name = "transcriptions/project.html"
@@ -285,10 +301,7 @@ class ConcordiaAssetView(TemplateView):
         """
         response = requests.get(
             "%s://%s/ws/asset/%s/"
-            % (
-                self.request.scheme,
-                self.request.get_host(),
-                self.args[0]),
+            % (self.request.scheme, self.request.get_host(), self.args[0]),
             cookies=self.request.COOKIES,
         )
         return json.loads(response.content.decode("utf-8"))
@@ -315,7 +328,10 @@ class ConcordiaAssetView(TemplateView):
             )
             transcription_json = json.loads(response.content.decode("utf-8"))
             if transcription_json["text"] == "":
-                return_path = "/campaigns/%s/asset/%s/" % (self.args[0], asset_item["slug"])
+                return_path = "/campaigns/%s/asset/%s/" % (
+                    self.args[0],
+                    asset_item["slug"],
+                )
                 break
 
         return return_path
@@ -333,25 +349,31 @@ class ConcordiaAssetView(TemplateView):
         asset_list_json = self.get_asset_list_json()
 
         def get_transcription(asset_item):
-                response = requests.get(
-                    "%s://%s/ws/transcription/%s/"
-                    % (self.request.scheme, self.request.get_host(), asset_item["id"]),
-                    cookies=self.request.COOKIES,
-                )
-                return json.loads(response.content.decode("utf-8"))
+            response = requests.get(
+                "%s://%s/ws/transcription/%s/"
+                % (self.request.scheme, self.request.get_host(), asset_item["id"]),
+                cookies=self.request.COOKIES,
+            )
+            return json.loads(response.content.decode("utf-8"))
 
-        for asset_item in asset_list_json["results"][asset_json["sequence"]:]:
+        for asset_item in asset_list_json["results"][asset_json["sequence"] :]:
             transcription_json = get_transcription(asset_item)
             if transcription_json["status"] != Status.COMPLETED:
-                return_path = "/campaigns/%s/asset/%s/" % (self.args[0], asset_item["slug"])
+                return_path = "/campaigns/%s/asset/%s/" % (
+                    self.args[0],
+                    asset_item["slug"],
+                )
                 break
 
         # no asset found, iterate the asset_list_json from beginning to this asset's sequence
         if return_path == url:
-            for asset_item in asset_list_json["results"][:asset_json["sequence"]]:
+            for asset_item in asset_list_json["results"][: asset_json["sequence"]]:
                 transcription_json = get_transcription(asset_item)
                 if transcription_json["status"] != Status.COMPLETED:
-                    return_path = "/campaigns/%s/asset/%s/" % (self.args[0], asset_item["slug"])
+                    return_path = "/campaigns/%s/asset/%s/" % (
+                        self.args[0],
+                        asset_item["slug"],
+                    )
                     break
 
         return return_path
@@ -427,12 +449,12 @@ class ConcordiaAssetView(TemplateView):
         captcha_form = CaptchaEmbedForm()
 
         response = requests.get(
-            "%s://%s/ws/page_in_use_user/%s/%s/" %
-            (
+            "%s://%s/ws/page_in_use_user/%s/%s/"
+            % (
                 self.request.scheme,
                 self.request.get_host(),
                 current_user_id,
-                in_use_url
+                in_use_url,
             ),
             cookies=self.request.COOKIES,
         )
@@ -464,21 +486,19 @@ class ConcordiaAssetView(TemplateView):
             change_page_in_use = {"page_url": in_use_url, "user": current_user_id}
 
             test_url = "%s://%s/ws/page_in_use_update/%s/%s/" % (
-
-                    self.request.scheme,
-                    self.request.get_host(),
-                    current_user_id,
-                    in_use_url
-                )
+                self.request.scheme,
+                self.request.get_host(),
+                current_user_id,
+                in_use_url,
+            )
 
             requests.put(
-                "%s://%s/ws/page_in_use_update/%s/%s/" %
-                (
-
+                "%s://%s/ws/page_in_use_update/%s/%s/"
+                % (
                     self.request.scheme,
                     self.request.get_host(),
                     current_user_id,
-                    in_use_url
+                    in_use_url,
                 ),
                 data=change_page_in_use,
                 cookies=self.request.COOKIES,
@@ -529,7 +549,7 @@ class ConcordiaAssetView(TemplateView):
 
         redirect_path = self.request.path
 
-        if "tx" in self.request.POST and 'tagging' not in self.request.POST:
+        if "tx" in self.request.POST and "tagging" not in self.request.POST:
             tx = self.request.POST.get("tx")
             tx_status = self.state_dictionary[self.request.POST.get("action")]
             requests.post(
@@ -551,7 +571,6 @@ class ConcordiaAssetView(TemplateView):
                 Status.EDIT: lambda x, y: x,
                 Status.SUBMITTED: self.submitted_page,
                 Status.COMPLETED: self.completed_page,
-
             }
 
             redirect_path = next_page_dictionary[tx_status](redirect_path, asset_json)
@@ -591,14 +610,18 @@ class ConcordiaAssetView(TemplateView):
 
             # delete "old" tags
             for old_tag in existing_tags_list:
-                response = requests.delete("%s://%s/ws/tag_delete/%s/%s/%s/%s/" %
-                                           (self.request.scheme,
-                                            self.request.get_host(),
-                                            self.args[0],
-                                            self.args[1],
-                                            old_tag,
-                                            self.request.user.id),
-                                           cookies=self.request.COOKIES)
+                response = requests.delete(
+                    "%s://%s/ws/tag_delete/%s/%s/%s/%s/"
+                    % (
+                        self.request.scheme,
+                        self.request.get_host(),
+                        self.args[0],
+                        self.args[1],
+                        old_tag,
+                        self.request.user.id,
+                    ),
+                    cookies=self.request.COOKIES,
+                )
 
             redirect_path += "#tab-tag"
 
@@ -631,13 +654,19 @@ class ConcordiaAlternateAssetView(View):
         if campaign_slug and asset_slug:
             response = requests.get(
                 "%s://%s/ws/campaign_asset_random/%s/%s"
-                % (self.request.scheme, self.request.get_host(), campaign_slug, asset_slug),
+                % (
+                    self.request.scheme,
+                    self.request.get_host(),
+                    campaign_slug,
+                    asset_slug,
+                ),
                 cookies=self.request.COOKIES,
             )
             random_asset_json_val = json.loads(response.content.decode("utf-8"))
 
             return HttpResponse(
-                "/campaigns/%s/asset/%s/" % (campaign_slug, random_asset_json_val["slug"])
+                "/campaigns/%s/asset/%s/"
+                % (campaign_slug, random_asset_json_val["slug"])
             )
 
 
@@ -679,13 +708,12 @@ class ConcordiaPageInUse(View):
             change_page_in_use = {"page_url": page_url, "user": user_json_val["id"]}
 
             requests.put(
-                "%s://%s/ws/page_in_use_update/%s/%s/" %
-                (
-
+                "%s://%s/ws/page_in_use_update/%s/%s/"
+                % (
                     self.request.scheme,
                     self.request.get_host(),
                     user_json_val["id"],
-                    page_url
+                    page_url,
                 ),
                 data=change_page_in_use,
                 cookies=self.request.COOKIES,
@@ -787,11 +815,11 @@ class DeleteCampaignView(TemplateView):
     """
 
     def get(self, request, *args, **kwargs):
-        requests.delete("%s://%s/ws/campaign_delete/%s/" %
-                        (self.request.scheme,
-                         self.request.get_host(),
-                         self.args[0]),
-                        cookies=self.request.COOKIES)
+        requests.delete(
+            "%s://%s/ws/campaign_delete/%s/"
+            % (self.request.scheme, self.request.get_host(), self.args[0]),
+            cookies=self.request.COOKIES,
+        )
 
         os.system(
             "rm -rf {0}".format(settings.MEDIA_ROOT + "/concordia/" + self.args[0])
@@ -809,8 +837,8 @@ class DeleteAssetView(TemplateView):
         asset_update = {"campaign": self.args[0], "slug": self.args[1]}
 
         requests.put(
-            "%s://%s/ws/asset_update/%s/%s/" %
-            (
+            "%s://%s/ws/asset_update/%s/%s/"
+            % (
                 self.request.scheme,
                 self.request.get_host(),
                 self.args[0],
@@ -827,6 +855,7 @@ class ReportCampaignView(TemplateView):
     """
     Report the campaign
     """
+
     template_name = "transcriptions/report.html"
 
     def __init__(self):
@@ -841,8 +870,7 @@ class ReportCampaignView(TemplateView):
         """
 
         response = requests.get(
-            "%s://%s/ws/tags/%s/"
-            % (request.scheme, request.get_host(), asset_id),
+            "%s://%s/ws/tags/%s/" % (request.scheme, request.get_host(), asset_id),
             cookies=self.request.COOKIES,
         )
         existing_tags_json_val = json.loads(response.content.decode("utf-8"))
@@ -888,8 +916,12 @@ class ReportCampaignView(TemplateView):
 
             self.transcription_json_dict[asset] = transcription_json
 
-        return 1 if len(self.transcription_json_dict[asset]["text"]) > 0 and \
-                    self.transcription_json_dict[asset]["status"] == status else 0
+        return (
+            1
+            if len(self.transcription_json_dict[asset]["text"]) > 0
+            and self.transcription_json_dict[asset]["status"] == status
+            else 0
+        )
 
     def get_transcribe_user_count(self, request, asset_slug):
         """
@@ -937,13 +969,21 @@ class ReportCampaignView(TemplateView):
             total_tags = 0
 
             for asset in sorted_project["campaign"]["assets"]:
-                transcription_count += self.get_asset_transcribe_count(request, asset["id"])
-                transcription_edit_count += self.get_asset_transcribe_count_by_status(request, asset["id"], Status.EDIT)
-                transcription_submitted_count += self.get_asset_transcribe_count_by_status(request, asset["id"],
-                                                                                           Status.SUBMITTED)
-                transcription_complete_count += self.get_asset_transcribe_count_by_status(request, asset["id"],
-                                                                                          Status.COMPLETED)
-                asset_user_array = self.get_transcribe_user_count(request, asset["slug"])
+                transcription_count += self.get_asset_transcribe_count(
+                    request, asset["id"]
+                )
+                transcription_edit_count += self.get_asset_transcribe_count_by_status(
+                    request, asset["id"], Status.EDIT
+                )
+                transcription_submitted_count += self.get_asset_transcribe_count_by_status(
+                    request, asset["id"], Status.SUBMITTED
+                )
+                transcription_complete_count += self.get_asset_transcribe_count_by_status(
+                    request, asset["id"], Status.COMPLETED
+                )
+                asset_user_array = self.get_transcribe_user_count(
+                    request, asset["slug"]
+                )
                 for asset_user in asset_user_array:
                     if asset_user not in user_array:
                         user_array.append(asset_user)
@@ -951,7 +991,9 @@ class ReportCampaignView(TemplateView):
                 total_tags += self.get_asset_tag_count(request, asset["id"])
 
             sorted_project["total"] = len(sorted_project["campaign"]["assets"])
-            sorted_project["not_started"] = sorted_project["total"] - transcription_count
+            sorted_project["not_started"] = (
+                sorted_project["total"] - transcription_count
+            )
             sorted_project["edit"] = transcription_edit_count
             sorted_project["submitted"] = transcription_submitted_count
             sorted_project["complete"] = transcription_complete_count

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta
 from logging import getLogger
 from types import SimpleNamespace
 
-import requests
 from captcha.fields import CaptchaField
 from django.conf import settings
 from django.contrib import messages
@@ -251,34 +250,34 @@ class ConcordiaItemView(TemplateView):
     """
     Handle GET requests on /campaign/<campaign>/<project>/<item>
     """
+
     template_name = "transcriptions/item.html"
 
     def get_context_data(self, **kws):
+        from .serializers import ItemSerializer
 
-        response = requests.get(
-            "%s://%s/ws/item_by_id/%s"
-            % (self.request.scheme, self.request.get_host(), self.args[2]),
-            cookies=self.request.COOKIES,
+        item = get_object_or_404(
+            Item,
+            # FIXME: name the URL pattern components
+            campaign__slug=self.args[0],
+            project__slug=self.args[1],
+            slug=self.args[2],
         )
-        item_json_val = json.loads(response.content.decode("utf-8"))
-        assets_json_val = item_json_val["assets"]
 
-        paginator = Paginator(assets_json_val, ASSETS_PER_PAGE)
+        serialized = ItemSerializer(item).data
 
-        if not self.request.GET.get("page"):
-            page = 1
-        else:
-            page = self.request.GET.get("page")
+        paginator = Paginator(serialized["assets"], ASSETS_PER_PAGE)
+
+        page = int(self.request.GET.get("page") or "1")
 
         assets = paginator.get_page(page)
 
-        return dict(
-            super().get_context_data(**kws),
-            campaign=item_json_val["campaign"],
-            project=item_json_val["project"],
-            item=item_json_val,
-            assets=assets,
-        )
+        return super().get_context_data(**kws) + {
+            "campaign": serialized["campaign"],
+            "project": serialized["project"],
+            "item": serialized,
+            "assets": assets,
+        }
 
 
 class ConcordiaAssetView(TemplateView):

--- a/concordia/views_ws.py
+++ b/concordia/views_ws.py
@@ -9,12 +9,29 @@ from rest_framework import exceptions, generics, status
 from rest_framework.authentication import BasicAuthentication
 from rest_framework.response import Response
 
-from .models import (Asset, Campaign, Item, PageInUse, Status, Tag, Transcription, User, UserProfile,
-                     UserAssetTagCollection)
-from .serializers import (AssetSerializer, CampaignDetailSerializer,
-                          ItemSerializer,
-                          PageInUseSerializer, TagSerializer, TranscriptionSerializer,
-                          UserAssetTagSerializer, UserSerializer, UserProfileSerializer)
+from .models import (
+    Asset,
+    Campaign,
+    Item,
+    PageInUse,
+    Status,
+    Tag,
+    Transcription,
+    User,
+    UserAssetTagCollection,
+    UserProfile,
+)
+from .serializers import (
+    AssetSerializer,
+    CampaignDetailSerializer,
+    ItemSerializer,
+    PageInUseSerializer,
+    TagSerializer,
+    TranscriptionSerializer,
+    UserAssetTagSerializer,
+    UserProfileSerializer,
+    UserSerializer,
+)
 
 
 class ConcordiaAPIAuth(BasicAuthentication):
@@ -38,6 +55,7 @@ class AnonymousUserGet(generics.RetrieveAPIView):
     """
     GET: Return anonymous user, Create it if needed (this is not the AnonymousUser django user)
     """
+
     model = User
     authentication_classes = (ConcordiaAPIAuth,)
     queryset = User.objects.all()
@@ -58,6 +76,7 @@ class UserProfileGet(generics.RetrieveAPIView):
     """
     GET: Return a user profile
     """
+
     model = UserProfile
     authentication_classes = (ConcordiaAPIAuth,)
     queryset = UserProfile.objects.all()
@@ -67,9 +86,7 @@ class UserProfileGet(generics.RetrieveAPIView):
     def get_object(self):
         try:
             user = User.objects.get(id=int(self.kwargs["user_id"]))
-            return (
-                UserProfile.objects.get(user=user)
-            )
+            return UserProfile.objects.get(user=user)
         except ObjectDoesNotExist:
             return None
 
@@ -78,6 +95,7 @@ class UserGet(generics.RetrieveAPIView):
     """
     GET: Return a User
     """
+
     model = User
     authentication_classes = (ConcordiaAPIAuth,)
     queryset = User.objects.all()
@@ -153,6 +171,7 @@ class PageInUseCount(generics.RetrieveAPIView):
     """
     GET: Return True if the page is in use by a different user, otherwise False
     """
+
     model = PageInUse
     authentication_classes = (ConcordiaAPIAuth,)
     serializer_class = PageInUseSerializer
@@ -162,15 +181,17 @@ class PageInUseCount(generics.RetrieveAPIView):
     def get(self, request, *args, **kwargs):
         time_threshold = datetime.now() - timedelta(minutes=5)
         page_in_use_count = (
-            PageInUse.objects.filter(page_url=self.kwargs["page_url"], updated_on__gt=time_threshold)
-                .exclude(user__id=self.kwargs["user"])
-                .count()
+            PageInUse.objects.filter(
+                page_url=self.kwargs["page_url"], updated_on__gt=time_threshold
+            )
+            .exclude(user__id=self.kwargs["user"])
+            .count()
         )
 
         if page_in_use_count > 0:
-            return Response(data={'page_in_use': True})
+            return Response(data={"page_in_use": True})
         else:
-            return Response(data={'page_in_use': False})
+            return Response(data={"page_in_use": False})
 
 
 class PageInUsePut(generics.UpdateAPIView):
@@ -228,8 +249,6 @@ class CampaignGetById(generics.RetrieveAPIView):
     lookup_field = "id"
 
 
-
-
 class CampaignAssetsGet(generics.RetrieveAPIView):
     """
     GET: Retrieve an existing Campaign
@@ -265,9 +284,7 @@ class ItemGetById(generics.RetrieveAPIView):
     lookup_field = "item_id"
 
     def get_queryset(self):
-        return Item.objects.filter(
-            slug=self.kwargs["item_id"],
-        )
+        return Item.objects.filter(slug=self.kwargs["item_id"])
 
 
 class AssetsList(generics.ListAPIView):
@@ -281,9 +298,9 @@ class AssetsList(generics.ListAPIView):
     lookup_field = "campaign"
 
     def get_queryset(self):
-        return Asset.objects.filter(
-            campaign__slug=self.kwargs["campaign"]
-        ).order_by("title", "sequence")
+        return Asset.objects.filter(campaign__slug=self.kwargs["campaign"]).order_by(
+            "title", "sequence"
+        )
 
 
 class AssetBySlug(generics.RetrieveAPIView):
@@ -310,6 +327,7 @@ class AssetRandomInCampaign(generics.RetrieveAPIView):
     """
     GET: Return a random asset from the campaign excluding the passed in asset slug
     """
+
     model = Asset
     authentication_classes = (ConcordiaAPIAuth,)
     serializer_class = AssetSerializer
@@ -317,11 +335,14 @@ class AssetRandomInCampaign(generics.RetrieveAPIView):
 
     def get_object(self):
         try:
-            return (Asset.objects.filter(campaign__slug=self.kwargs["campaign"], status=Status.EDIT)
-                    .exclude(slug=self.kwargs["slug"])
-                    .order_by("?")
-                    .first()
-                    )
+            return (
+                Asset.objects.filter(
+                    campaign__slug=self.kwargs["campaign"], status=Status.EDIT
+                )
+                .exclude(slug=self.kwargs["slug"])
+                .order_by("?")
+                .first()
+            )
         except ObjectDoesNotExist:
             return None
 
@@ -353,9 +374,6 @@ class AssetUpdate(generics.UpdateAPIView):
         if serializer.is_valid():
             pass
         return Response(serializer.data)
-
-
-
 
 
 class PageInUseFilteredGet(generics.ListAPIView):
@@ -437,9 +455,9 @@ class TranscriptionByAsset(generics.ListAPIView):
         Return the transcriptions for an asset
         :return: Transcription object list
         """
-        return Transcription.objects.filter(asset__slug=self.kwargs["asset_slug"]).order_by(
-            "-updated_on"
-        )
+        return Transcription.objects.filter(
+            asset__slug=self.kwargs["asset_slug"]
+        ).order_by("-updated_on")
 
 
 class TranscriptionCreate(generics.CreateAPIView):

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -43,10 +43,9 @@ If you are proposing a feature:
 * Remember that this is a volunteer-driven project, and that contributions
   are welcome :)
 
-Get Started!
-------------
+### Get Started!
 
-Ready to contribute? Check out our [README](https://github.com/LibraryOfCongress/concordia/blob/master/README.rst) on how to set up your machine for local development.
+Ready to contribute? Check out our [README](https://github.com/LibraryOfCongress/concordia#concordia) on how to set up your machine for local development.
 
 1. Fork the `concordia` repo on GitHub.
 2. Clone your fork locally:
@@ -55,13 +54,7 @@ Ready to contribute? Check out our [README](https://github.com/LibraryOfCongress
     $ git clone git@github.com:your_name_here/concordia.git
     ```
 
-3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
-
-    ```
-    $ mkvirtualenv concordia
-    $ cd concordia/
-    $ python setup.py develop
-    ```
+3. Install your local copy to your virtual environment. Follow the instructions on [installing pipenv in our README](https://github.com/LibraryOfCongress/concordia/blob/2b211d3054fb681edb28adfab37928ad80ff859c/README.rst#serve)
 
 4. Create a branch for local development:
 
@@ -90,4 +83,4 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python [add versions here]
+3. The pull request should work for Python `3.6`

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contributing
+
+
+Contributions are welcome and are greatly appreciated! Every little bit helps, and credit will always be given.
+
+You can contribute in many ways:
+
+## Types of Contributions
+
+### Report Bugs
+
+
+Report bugs by [submitting an issue](https://github.com/LibraryOfCongress/concordia/issues).
+
+If you are reporting a bug, please include:
+
+* Your operating system name and version.
+* Any details about your local setup that might be helpful in troubleshooting.
+* Detailed steps to reproduce the bug.
+
+### Submit a pull request to fix bugs
+
+Look through the GitHub issues for bugs. Anything tagged with "bug" is open to whoever wants to implement it.
+
+### Submit a pull request to implement features
+
+Look through the GitHub issues for features. Anything tagged with "feature" is open to whoever wants to implement it.
+
+### Write Documentation
+
+
+Concordia could always use more documentation. If you have worked in the tool and found any of our documentation in accurate or requires more specificity, submit an issue or a pull request. 
+
+### How to submit Feedback
+
+
+The best way to send feedback is to file an issue at https://github.com/LibraryOfCongress/concordia/issues.
+
+If you are proposing a feature:
+
+* Explain in detail how it would work.
+* Keep the scope as narrow as possible, to make it easier to implement.
+* Remember that this is a volunteer-driven project, and that contributions
+  are welcome :)
+
+Get Started!
+------------
+
+Ready to contribute? Check out our [README](https://github.com/LibraryOfCongress/concordia/blob/master/README.rst) on how to set up your machine for local development.
+
+1. Fork the `concordia` repo on GitHub.
+2. Clone your fork locally:
+
+    ```
+    $ git clone git@github.com:your_name_here/concordia.git
+    ```
+
+3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
+
+    ```
+    $ mkvirtualenv concordia
+    $ cd concordia/
+    $ python setup.py develop
+    ```
+
+4. Create a branch for local development:
+
+    `$ git checkout -b name-of-your-bugfix-or-feature`
+
+   Now you can make your changes locally.
+
+5. When you're done making changes, run your code through the Library's coding standards. You can find step by step instructions in the [README](https://github.com/LibraryOfCongress/concordia#code-quality):
+
+6. Commit your changes and push your branch to GitHub:
+
+    ```
+    $ git add .
+    $ git commit -m "Your detailed description of your changes."
+    $ git push origin name-of-your-bugfix-or-feature
+    ```
+
+7. Submit a pull request through the GitHub website.
+
+Pull Request Guidelines
+-----------------------
+
+Before you submit a pull request, check that it meets these guidelines:
+
+1. The pull request should include tests.
+2. If the pull request adds functionality, the docs should be updated. Put
+   your new functionality into a function with a docstring, and add the
+   feature to the list in README.rst.
+3. The pull request should work for Python [add versions here]


### PR DESCRIPTION
Calling the API from inside a view opens up a number of
potential problems (app instances may not have complete
internet access to public API endpoints, the code will block
if the web server is close to maximum capacity and queues
requests, etc.) and has a substantial performance penalty.
This changes the requests call to simply load the item and
serialize it directly so the data is in the same format as
the API but without the encode/transfer/decode overhead.
This pattern will need to be applied throughout the other
views but long term it would probably be better to simply
enable django-rest-framework’s built-in template renderer
for any view which is supposed to have this 1:1 data
correspondence.