### PR TITLE
Enable error logging to Sentry

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -28,6 +28,7 @@ responses = "*"
 python-dotenv = "*"
 django-elasticsearch-dsl = "*"
 elasticsearch-dsl = "==6.1.0"
+raven = "*"
 
 [dev-packages]
 invoke = "*"

--- a/concordia/context_processors.py
+++ b/concordia/context_processors.py
@@ -1,0 +1,9 @@
+from django.conf import settings
+
+
+def system_configuration(request):
+    """
+    Expose some system configuration to the default template context
+    """
+
+    return {"SENTRY_PUBLIC_DSN": getattr(settings, "SENTRY_PUBLIC_DSN", None)}

--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -205,10 +205,19 @@ LOGGING = {
             "formatter": "long",
             "maxBytes": 1024 * 1024 * 100,  # 100 mb
         },
+        'sentry': {
+            'level': 'WARNING',
+            'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
+        },
     },
     "loggers": {
         "django": {"handlers": ["file", "stream"], "level": "DEBUG", "propagate": True},
         "celery": {"handlers": ["celery", "stream"], "level": "DEBUG"},
+        'sentry.errors': {
+            'level': 'INFO',
+            'handlers': ['stream'],
+            'propagate': False,
+        },
     },
 }
 

--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -18,6 +18,8 @@ load_dotenv(dotenv_path)
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = "django-secret-key"
 
+CONCORDIA_ENVIRONMENT = os.environ.get("CONCORDIA_ENVIRONMENT", "development")
+
 # Optional SMTP authentication information for EMAIL_HOST.
 EMAIL_HOST_USER = ""
 EMAIL_HOST_PASSWORD = ""
@@ -74,6 +76,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "raven.contrib.django.raven_compat",
     "rest_framework",
     "concordia",
     "exporter",
@@ -119,6 +122,8 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "django.template.context_processors.media",
+                # Concordia
+                "concordia.context_processors.system_configuration",
                 # Machina
                 "machina.core.context_processors.metadata",
             ],
@@ -267,3 +272,9 @@ REGISTRATION_OPEN = True  # set to false to temporarily disable registrations
 MESSAGE_TAGS = {
     messages.ERROR: 'danger',
 }
+
+SENTRY_DSN = os.environ.get("SENTRY_DSN", "")
+SENTRY_PUBLIC_DSN = os.environ.get("SENTRY_PUBLIC_DSN", "")
+
+if SENTRY_DSN:
+    RAVEN_CONFIG = {"dsn": SENTRY_DSN, "environment": CONCORDIA_ENVIRONMENT}

--- a/concordia/templates/base.html
+++ b/concordia/templates/base.html
@@ -355,6 +355,10 @@
         </div>
     </footer>
     <!-- JS -->
+    {% if SENTRY_PUBLIC_DSN %}
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/raven.js/3.26.1/raven.min.js" integrity="sha256-N3YzTdAC27tvNKpIM2rly/WvlJf8YAat0NjPXgh5Bw4=" crossorigin="anonymous"></script>
+        <script>Raven.config('{{ SENTRY_PUBLIC_DSN }}').install()</script>
+    {% endif %}
     <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>


### PR DESCRIPTION
This assumes that the `SENTRY_DSN` and `SENTRY_PUBLIC_DSN` environmental variables are actually set and uses the `CONCORDIA_ENVIRONMENT` variable to set the reported environment.